### PR TITLE
Change reader macro syntax to use a trailing backslash

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,15 +240,69 @@ A symbol that begins with a `:` is a "keyword".
 Keywords are never interpreted as identifiers,
 so they don't need to be quoted or munged.
 
-Reader macros consist of a symbol beginning with a `\ ` followed by another form.
+Reader macros consist of a symbol ending with a `\ `
+followed by another form.
 The function named by the symbol is invoked on the form,
 and the reader inserts the resulting object into the output code.
 
-There are also four built-in reader macros that don't start with `\ `:
+For example,
+```
+## builtins..float\inf
+>>>  __import__('pickle').loads(  # inf
+...     b'\x80\x03G\x7f\xf0\x00\x00\x00\x00\x00\x00.'
+... )
+inf
+```
+This inserts an actual `inf` object at read time into the Hissp code.
+Since this isn't a valid literal, it has to compile to a pickle.
+You should normally try to avoid emitting pickles
+(e.g. use `(float 'inf)` or `math..inf` instead),
+but note that a macro would get the original object,
+since the code hasn't been compiled yet, which may be useful.
+While unpickling does have some overhead,
+it may be worth it if constructing the object normally has even more.
+Naturally, the object must be picklable to emit a pickle.
+
+Unqualified reader macros are reserved for the basic Hissp reader.
+There are currently three of them: `.\ `, `_\ `, and `#\ `.
+
+If you need more than one argument for a reader macro, use the built in
+`.\ ` macro, which evaluates a form at read time. For example,
+```
+## .\(fractions..Fraction 1 2)
+
+>>>  __import__('pickle').loads(  # Fraction(1, 2)
+...     b'\x80\x03cfractions\nFraction\nX\x03\x00\x00\x001/2\x85R.'
+... )
+Fraction(1, 2)
+```
+
+The `_\ ` macro omits the next form.
+It's a way to comment out code,
+even if it takes multiple lines.
+
+There are also four more built-in reader macros that don't end with `\ `:
 * ``` ` ``` template quote
 * `,` unquote
 * `,@` splice unquote
 * `'` quote
+
+The final builtin `#\ ` creates a gensym based on the given symbol.
+Within a template, the same gensym literal always makes the same
+gensym.
+```python
+## '(#\hiss #\hiss)  ; Note different numbers.
+
+>>>  ('_hissxAUTO1_', '_hissxAUTO2_')
+('_hissxAUTO1_', '_hissxAUTO2_')
+
+## `(#\hiss #\hiss)  ; Note template quote, and the same number.
+
+>>>  (lambda *a:a)(
+...   '_hissxAUTO3_',
+...   '_hissxAUTO3_')
+('_hissxAUTO3_', '_hissxAUTO3_')
+```
 
 #### Calls and the compiler
 

--- a/hissp/reader.py
+++ b/hissp/reader.py
@@ -27,7 +27,7 @@ TOKENS = re.compile(
 |(?P<macro>
    ,@
   |['`,]
-  |\\[^ \n"()\\]*(?=[\n ("\\]))
+  |[^ \n"()\\]*\\)
 |(?P<symbol>[^ \n"()\\]+)
 """
 )
@@ -113,8 +113,8 @@ class Parser:
         if tag == ",@":
             return _Unquote([":*", form])
 
-        assert tag.startswith("\\")
-        tag = tag[1:]
+        assert tag.endswith("\\")
+        tag = tag[:-1]
         if tag == "_":
             return DROP
         if tag == "#":


### PR DESCRIPTION
I think it looks nicer, and this way we don't have to use a lookahead in the regex, or a space for one applied to a symbol.