### PR TITLE
Fix issue with compile-time local imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ gensym.
 #> `($#hiss $#hiss)
 #..
 >>> (lambda *xAUTO0_:xAUTO0_)(
-...   '_hissxAUTO15_',
-...   '_hissxAUTO15_')
-('_hissxAUTO15_', '_hissxAUTO15_')
+...   '_hissxAUTO16_',
+...   '_hissxAUTO16_')
+('_hissxAUTO16_', '_hissxAUTO16_')
 
 ```
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -757,9 +757,9 @@ Within a template, the same gensym name always makes the same gensym::
     #> `($#hiss $#hiss)
     #..
     >>> (lambda *xAUTO0_:xAUTO0_)(
-    ...   '_hissxAUTO20_',
-    ...   '_hissxAUTO20_')
-    ('_hissxAUTO20_', '_hissxAUTO20_')
+    ...   '_hissxAUTO21_',
+    ...   '_hissxAUTO21_')
+    ('_hissxAUTO21_', '_hissxAUTO21_')
 
 But each new template increments the counter.
 Gensyms are mainly used to prevent accidental name collisions in generated code.

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -337,7 +337,7 @@ class Compiler:
             parts = symbol.split("..", 1)
             if parts[0] == self.qualname:  # This module. No import required.
                 chain = parts[1].split('.', 1)
-                chain[0] = f"globals()[{chain[0]}]"  # Avoid local shadowing.
+                chain[0] = f"globals()[{self.quoted(chain[0])}]"  # Avoid local shadowing.
                 return '.'.join(chain)
             return "__import__({0!r}{fromlist}).{1}".format(
                 parts[0], parts[1], fromlist=",fromlist='?'" if "." in parts[0] else ""

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -1,16 +1,23 @@
 # Copyright 2019 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
 import traceback
+from contextlib import suppress
 from functools import partial
 from types import SimpleNamespace
 
-import hissp.basic
 from hissp.reader import Parser
+from hissp.reader import transpile
 
 
-def repl():
+def repl(macros=None):
     parser = Parser()
-    parser.compiler.ns["_macro_"] = SimpleNamespace(**vars(hissp.basic._macro_))
+    if not macros:
+        with suppress():
+            transpile("hissp", "basic")
+        from hissp import basic
+
+        macros = basic
+    parser.compiler.ns["_macro_"] = SimpleNamespace(**vars(macros._macro_))
     while True:
         try:
             try:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,4 @@
 from hissp.reader import transpile
 
-transpile(__package__, "test_basic")
-
 transpile("hissp", "basic")
+transpile(__package__, "test_basic")

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -2,9 +2,21 @@
 ;; SPDX-License-Identifier: Apache-2.0
 
 (hissp.basic.._macro_.from-require
- (hissp.basic deftype let cascade if-else progn))
+ (hissp.basic define deftype defmacro let cascade if-else progn))
+
+(define entuple
+  (lambda (: :* a) a))
+
+(defmacro tqs ()
+  None
+  `(entuple 'entuple))
 
 (deftype TestBasic (unittest..TestCase)
+  test_qualified_symbol
+  (lambda (self)
+    (.assertEqual self
+                  (tqs)
+                  '(tests.test_basic..entuple)))
   test_let
   (lambda (self)
     (let (x 1


### PR DESCRIPTION
And update tests for it.
A macro may use a variable from the same module later.

The last merge was supposed to have fixed this, but I had updated it again to fix a shadowing issue without retesting properly. This one adds a unit test for the edge case.