### PR TITLE
Allow ``xAUTO..._`` to match any number in document tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,9 +354,9 @@ gensym.
 #> `($#hiss $#hiss)
 #..
 >>> (lambda *xAUTO0_:xAUTO0_)(
-...   '_hissxAUTO16_',
-...   '_hissxAUTO16_')
-('_hissxAUTO16_', '_hissxAUTO16_')
+...   '_hissxAUTO..._',
+...   '_hissxAUTO..._')
+('_hissxAUTO..._', '_hissxAUTO..._')
 
 ```
 

--- a/conftest.py
+++ b/conftest.py
@@ -46,7 +46,7 @@ class ParseLissp(DocTestParser):
             parser.compiler.ns = example.namespace
             hissp = parser.reads(lissp)
             compiled = parser.compiler.compile(hissp) + "\n"
-            assert compiled == python, dedent(
+            assert norm_gensym_eq(compiled, python), dedent(
                 f"""
                 EXPECTED PYTHON:
                 {indent(python, "  ")}
@@ -57,6 +57,10 @@ class ParseLissp(DocTestParser):
             )
         return super().evaluate(example)
 
+
+def norm_gensym_eq(compiled, python):
+    """The special gensym suffix ``xAUTO..._`` will match any number."""
+    return re.fullmatch(re.sub(r'xAUTO\\\.\\\.\\\._', r'xAUTO\\d+_', re.escape(python)), compiled)
 
 class Globs(Container):
     def __init__(self, *globs):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,14 +12,15 @@
 
 import os
 import sys
-sys.path.insert(0, os.path.abspath('../src'))
+
+sys.path.insert(0, os.path.abspath("../src"))
 
 
 # -- Project information -----------------------------------------------------
 
-project = 'Hissp'
-copyright = '2019, Matthew Egan Odendahl'
-author = 'Matthew Egan Odendahl'
+project = "Hissp"
+copyright = "2019, Matthew Egan Odendahl"
+author = "Matthew Egan Odendahl"
 
 
 # -- General configuration ---------------------------------------------------
@@ -27,18 +28,15 @@ author = 'Matthew Egan Odendahl'
 # Add any Sphinx extension module names here, as strings. They can be
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
-extensions = [
-    'sphinx.ext.autodoc',
-    'sphinx.ext.intersphinx',
-]
+extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 
 # Add any paths that contain templates here, relative to this directory.
-templates_path = ['_templates']
+templates_path = ["_templates"]
 
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -46,12 +44,12 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 #
-html_theme = 'nature'
+html_theme = "nature"
 html_theme_options = dict(sidebarwidth=300)
 
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+html_static_path = ["_static"]
 
-intersphinx_mapping = {'python': ('https://docs.python.org/3', None)}
+intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -757,11 +757,13 @@ Within a template, the same gensym name always makes the same gensym::
     #> `($#hiss $#hiss)
     #..
     >>> (lambda *xAUTO0_:xAUTO0_)(
-    ...   '_hissxAUTO21_',
-    ...   '_hissxAUTO21_')
-    ('_hissxAUTO21_', '_hissxAUTO21_')
+    ...   '_hissxAUTO..._',
+    ...   '_hissxAUTO..._')
+    ('_hissxAUTO..._', '_hissxAUTO..._')
 
 But each new template increments the counter.
+(The numbers have been elided to make the doctests work, but they're the same
+as well. E.g. ``_hissxAUTO42_``. Try it.)
 Gensyms are mainly used to prevent accidental name collisions in generated code.
 
 Data Structures

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -12,6 +12,10 @@
   `(entuple 'entuple))
 
 (deftype TestBasic (unittest..TestCase)
+  test_same_gensym
+  (lambda (self)
+    (.assertEqual self : :* `($#test $#test)))
+
   test_qualified_symbol
   (lambda (self)
     (.assertEqual self


### PR DESCRIPTION
Just as doctest needs ellipsis to control for things that change but don't matter, the hissp doc tests now accept elided numbers in gensyms as any number. This could perhaps be generalized to elide anything as the doctests do, but so far, we don't need it.

Also adds a unit test to check the invariant that the doctests used to.