### PR TITLE
Compile hissp modules in Sphinx conf so autodoc can find them

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,9 @@ import sys
 
 sys.path.insert(0, os.path.abspath("../src"))
 
+# Compile hissp modules so autodoc can find them.
+from hissp.reader import transpile
+transpile("hissp", "basic")
 
 # -- Project information -----------------------------------------------------
 


### PR DESCRIPTION
Compiled files are not currently saved in the repository, but autodoc needs them to generate some of the documentation pages.