### PR TITLE
Add badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 Copyright 2019 Matthew Egan Odendahl
 SPDX-License-Identifier: Apache-2.0
 -->
+[![Gitter](https://badges.gitter.im/hissp-lang/community.svg)](https://gitter.im/hissp-lang/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)
+[![Documentation Status](https://readthedocs.org/projects/hissp/badge/?version=latest)](https://hissp.readthedocs.io/en/latest/?badge=latest)
 <!-- Hidden doctest requires basic macros for REPL-consistent behavior.
 #> (operator..setitem (globals) '_macro_ (types..SimpleNamespace : :** (vars hissp.basic.._macro_)))
 #..


### PR DESCRIPTION
The Gitter badger was supposed to badge the readme.
It forked the repo, but that's it. No branch, no push, no PR.
Bad badger. I'll badge it myself.

I'm also adding the readthedocs badge.