### PR TITLE
Run main

### DIFF
--- a/README.md
+++ b/README.md
@@ -909,18 +909,30 @@ Assign a string to the `__doc__` attribute of the module/class/function object.
 That means defining a `__doc__` global in the module.
 That key in the dict argument to `type()` also works.
 
-> The REPL is nice and all, but how do I compile a module?
+> The REPL is nice and all, but how do I run a ``.lissp`` module?
 
-```lisp
-(hissp.reader..transpile "hissp" "basic")
+You can use ``hissp`` to launch a ``.lissp`` file as the main module directly.
+
+If you have the entry point script installed that's:
+```shell script
+$ hissp foo.lissp
 ```
-or
+To be able to import a ``.lissp`` module, you must compile it to Python first.
+
+At the REPL (or main module if it's written in Lissp) use:
+```lisp
+(hissp.reader..transpile __package__ 'spam 'eggs 'etc)
+```
+Where spam, eggs, etc. are the module names you want compiled.
+(If the package argument is ``None`` or ``''``, it will use the current working directory.)
+
+Or equivalently, in Python:
 ```python
 from hissp.reader import transpile
 
-transpile(__package__, "spam", "eggs")
+transpile(__package__, "sausage", "bacon")
 ```
-Consider putting the above in `__init__.py` to auto-compile
+Consider putting the above in each package's `__init__.py` to auto-compile
 each Hissp module in the package on package import during development.
 You can disable it again on release, if desired,
 but this gives you fine-grained control over what gets compiled when.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -960,22 +960,22 @@ We can do better. Let's use a template::
     ...       'builtins..print',
     ...       (lambda *xAUTO0_:xAUTO0_)(
     ...         'quote',
-    ...         '_repl..Hello'),
+    ...         '__main__..Hello'),
     ...       name)))
 
     #> (greet 'Bob)
     #..
     >>> # greet
     ... __import__('builtins').print(
-    ...   '_repl..Hello',
+    ...   '__main__..Hello',
     ...   'Bob')
-    _repl..Hello Bob
+    __main__..Hello Bob
 
 Not what you expected?
 
 A template quote automatically qualifies any unqualified symbols it contains
-with ``builtins`` (if applicable) or the current ``__package__``
-(which is ``_repl``)::
+with ``builtins`` (if applicable) or the current ``__name__``
+(which is ``__main__``)::
 
     #> `int  ; Works directly on symbols too.
     >>> 'builtins..int'
@@ -985,8 +985,8 @@ with ``builtins`` (if applicable) or the current ``__package__``
     #..
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..int',
-    ...   '_repl..spam')
-    ('builtins..int', '_repl..spam')
+    ...   '__main__..spam')
+    ('builtins..int', '__main__..spam')
 
 Qualified symbols are especially important
 when a macro expands in a module it was not defined in.
@@ -1012,8 +1012,8 @@ symbol. (Like a quoted symbol)::
     #..
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..float',
-    ...   '_repl..inf')
-    ('builtins..float', '_repl..inf')
+    ...   '__main__..inf')
+    ('builtins..float', '__main__..inf')
 
     #> `(float ,'inf)
     #..

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -217,9 +217,14 @@ REPL
 
 You can launch the REPL from Python code (which is useful for debugging,
 like :obj:`code.iteract`),
-But let's just start it from the command line::
+But let's just start it from the command line using an appropriate Python interpreter::
 
     $ python -m hissp
+
+Or, if you installed the hissp package using pip,
+you can use the installed entry point script::
+
+    $ hissp
 
 You should see the Lissp prompt ``#>`` appear.
 
@@ -1122,23 +1127,49 @@ and do a find-and-replace on symbols in code all at once.
 You have full programmatic control over the *code itself*,
 with the full power of Python's ecosystem. The sky's the limit.
 
-Packages
-========
+Compiling Packages
+==================
 
-Consider putting the following in ``__init__.py`` to auto-compile
-each Hissp module in the package on package import during development::
+It isn't always necessary to create a compiled file.
+You can run a ``.lissp`` file directly as the main module using hissp::
+
+    $ python -m hissp foo.lissp
+
+Or::
+
+    $ hissp foo.lissp
+
+But you'll probably want to break a larger project up into smaller modules.
+And those must be compiled for import.
+
+The recommended way to compile a Lissp project is to put a call to
+``transpile()`` in the main module and in each ``__init__.py``—
+with the name of each top-level ``.lissp`` file,
+or ``.lissp`` file in the corresponding package,
+respectively::
 
     from hissp.reader import transpile
 
-    transpile(__package__, "spam", "eggs")
+    transpile(__package__, "spam", "eggs", "etc")
 
-You can disable it again on release, if desired,
-but this gives you fine-grained control over what gets compiled when.
+Or equivalently in Lissp, used either at the REPL or if the main module is written in Lissp::
+
+    (hissp.reader..transpile __package__ 'spam 'eggs 'etc)
+
+This will automatically compile each named Lissp module.
+This approach gives you fine-grained control over what gets compiled when.
+If desired, you can remove a name passed to the ``transpile()``
+call to stop recompiling that file.
+Then you can compile the file manually at the REPL as needed using ``transpile()``.
+
 Note that you usually *would* want to recompile the whole project
-rather than only the changed files like Python does,
+rather than only the changed files on import like Python does for ``.pyc`` files,
 because macros run at compile time.
 Changing a macro in one file normally doesn't affect the code that uses
 it in other files until they are recompiled.
+That is why transpile will recompile the named files unconditionally.
+Even if the corresponding source has not changed,
+the compiled output may be different due to an updated macro in another file.
 
 .. rubric:: Footnotes
 

--- a/src/hissp/__init__.py
+++ b/src/hissp/__init__.py
@@ -1,1 +1,1 @@
-from .repl import repl
+from . import repl

--- a/src/hissp/__main__.py
+++ b/src/hissp/__main__.py
@@ -1,4 +1,2 @@
-from .repl import repl
-
 if __name__ == "__main__":
-    repl()
+    __import__('hissp').repl.cmd(globals())

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -55,9 +55,9 @@ class Compiler:
     The Hissp compiler.
     """
 
-    def __init__(self, qualname="_repl", ns=None, evaluate=True):
+    def __init__(self, qualname="__main__", ns=None, evaluate=True):
         self.qualname = qualname
-        self.ns = ns or {"__name__": "<compiler>"}
+        self.ns = ns or {"__name__": qualname}
         self.evaluate = evaluate
         self.error = False
 
@@ -152,6 +152,7 @@ class Compiler:
 
         """
         # Number literals may need (). E.g. (1).real
+        # TODO: pretty-print without sorting dicts.
         literal = f"({form!r})" if type(form) in NUMBER else repr(form)
         with suppress(ValueError):
             if ast.literal_eval(literal) == form:
@@ -378,5 +379,5 @@ def pairs(it: Iterable[T]) -> Iterable[Tuple[T, T]]:
 
 
 def readerless(form, ns=None):
-    ns = ns or NS.get() or {"__name__": "<compiler>"}
+    ns = ns or NS.get() or {"__name__": "__main__"}
     return Compiler(evaluate=False, ns=ns).compile([form])

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -73,10 +73,10 @@ def gensym_counter(count=[0]):
 
 class Parser:
     def __init__(
-        self, qualname="_repl", ns=None, verbose=False, evaluate=False, filename="<?>"
+        self, qualname="__main__", ns=None, verbose=False, evaluate=False, filename="<?>"
     ):
         self.qualname = qualname
-        self.ns = ns or {"__name__": "<compiler>"}
+        self.ns = ns or {"__name__": qualname}
         self.compiler = Compiler(self.qualname, self.ns, evaluate)
         self.verbose = verbose
         self.filename = filename

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -12,7 +12,7 @@ from itertools import chain
 from pathlib import Path, PurePath
 from pprint import pprint
 from types import ModuleType
-from typing import Any, Iterable, Iterator, NewType, Tuple, Union
+from typing import Any, Iterable, Iterator, NewType, Tuple, Union, Optional
 from unittest.mock import ANY
 
 from hissp.compiler import Compiler, readerless
@@ -225,9 +225,18 @@ def is_string(form):
     return form == ("quote", ANY, ANY) and form[2].get(":str")
 
 
-def transpile(package: resources.Package, *modules: Union[str, PurePath]):
-    for module in modules:
-        transpile_module(package, module + ".lissp")
+def transpile(package: Optional[resources.Package], *modules: Union[str, PurePath]):
+    if package:
+        for module in modules:
+            transpile_module(package, module + ".lissp")
+    else:
+        for module in modules:
+            with open(module+'.lissp') as f:
+                code = f.read()
+            out = module + '.py'
+            with open(out, "w") as f:
+                print("writing to", out)
+                f.write(Parser(module, evaluate=True, filename=str(out)).compile(code))
 
 
 def transpile_module(

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -1,5 +1,7 @@
 # Copyright 2019 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
+import os
+import sys
 import traceback
 from contextlib import suppress
 from functools import partial
@@ -48,3 +50,16 @@ def _get_more(line):
     if "(" in line or '"' in line or ";" in line:
         buffer.extend(iter(partial(input, "#.."), ""))
     return buffer
+
+def cmd(ns):
+    case = len(sys.argv)
+    if case == 2:
+        ns['__file__'] = filename = os.path.abspath(sys.argv[1])
+        with open(filename) as f:
+            Parser(
+                ns=ns, filename=filename, evaluate=True
+            ).compile(f.read())
+    elif case == 1:
+        repl()
+    else:
+        raise TypeError

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -55,6 +55,7 @@ def cmd(ns):
     case = len(sys.argv)
     if case == 2:
         ns['__file__'] = filename = os.path.abspath(sys.argv[1])
+        ns['__package__'] = None
         with open(filename) as f:
             Parser(
                 ns=ns, filename=filename, evaluate=True


### PR DESCRIPTION
Mostly takes care of #39, but still needs more tests. I might have to use subprocess to test these properly though. And there's more package metadata I'm still not sure about. That should all work fine at runtime since it's just Python. Compile time maybe doesn't need it. But for the main module, there's only compile time.