### PR TITLE
Py3.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ This gives Hissp a massive advantage over other Lisps with less selection.
 If you don't care to work with the Python ecosystem,
 perhaps Hissp is not the Lisp for you.
 
-Note that the Hissp compiler is written in Python 3.7.
+Note that the Hissp compiler is written in Python 3.8.
 (Supporting older versions is not a goal,
 because that would complicate the compiler.
 This may limit the available libraries.)
@@ -447,7 +447,14 @@ Here's the earlier example quoted.
 ```python
 #> (quote (builtins..print 1 2j 3.0 [4,'5',6] : sep ":"))
 #..
->>> ('builtins..print', 1, 2j, 3.0, [4, '5', 6], ':', 'sep', ('quote', ':', {':str': True}))
+>>> ('builtins..print',
+...  1,
+...  2j,
+...  3.0,
+...  [4, '5', 6],
+...  ':',
+...  'sep',
+...  ('quote', ':', {':str': True}))
 ('builtins..print', 1, 2j, 3.0, [4, '5', 6], ':', 'sep', ('quote', ':', {':str': True}))
 
 ```

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ For example,
 ```python
 #> builtins..float#inf
 >>> __import__('pickle').loads(  # inf
-...     b'\x80\x03G\x7f\xf0\x00\x00\x00\x00\x00\x00.'
+...     b'Finf\n.'
 ... )
 inf
 
@@ -329,7 +329,7 @@ If you need more than one argument for a reader macro, use the built in
 #> .#(fractions..Fraction 1 2)
 #..
 >>> __import__('pickle').loads(  # Fraction(1, 2)
-...     b'\x80\x03cfractions\nFraction\nX\x03\x00\x00\x001/2\x85R.'
+...     b'cfractions\nFraction\n(V1/2\ntR.'
 ... )
 Fraction(1, 2)
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -453,13 +453,14 @@ The parameters tuple is divided into ``(<single> : <paired>)``
 Parameter types are the same as Python's.
 For example::
 
-    #> (lambda (a b  ; positional
+    #> (lambda (a :/  ; positional only
+    #..         b  ; positional
     #..         : e 1  f 2  ; default
     #..         :* args  h 4  i :?  j 1  ; kwonly
     #..         :** kwargs)
     #..  42)
     #..
-    >>> (lambda a,b,e=(1),f=(2),*args,h=(4),i,j=(1),**kwargs:(42))
+    >>> (lambda a,/,b,e=(1),f=(2),*args,h=(4),i,j=(1),**kwargs:(42))
     <function <lambda> at ...>
 
 The special keywords ``:*`` and ``:**`` designate the remainder of the
@@ -491,10 +492,18 @@ You can omit the right of a pair with ``:?``
 (except the final ``**kwargs``).
 Also note that the body can be empty::
 
-    #> (lambda (: a 1 :* :?  b :?  c 2))
+    #> (lambda (: a 1  :/ :?  :* :?  b :?  c 2))
     #..
-    >>> (lambda a=(1),*,b,c=(2):())
+    >>> (lambda a=(1),/,*,b,c=(2):())
     <function <lambda> at ...>
+
+Note that positional-only arguments must appear after the ``:``
+when they have defaults, which forces the ``:/`` into the paired side.
+Everything on the paired side must be paired, no exceptions.
+(Even though ``:/`` can only be paired with ``:?``,
+special casing that to not require the ``:?``
+would make macro writing more difficult,
+because then they would also need to handle another special case.)
 
 The ``:`` may be omitted if there are no paired parameters::
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -724,20 +724,19 @@ The splice unquote is similar, but unpacks its result::
 Templates are *reader syntax*: because they're reader macros,
 they only exist in Lissp, not Hissp. The Hissp is what they return.
 
-If you quote and pretty-print an example, you can see that intermediate step::
+If you quote an example, you can see that intermediate step::
 
-    #> (pprint..pprint '`(:a ,@"bcd" ,(opearator..mul 2 3)))
+    #> '`(:a ,@"bcd" ,(opearator..mul 2 3))
     #..
-    >>> __import__('pprint').pprint(
-    ...   (('lambda', (':', ':*', 'xAUTO0_'), 'xAUTO0_'), ':', ':?', ':a', ':*', ('quote', 'bcd', {':str': True}), ':?', ('opearator..mul', 2, 3)))
-    (('lambda', (':', ':*', 'xAUTO0_'), 'xAUTO0_'),
-     ':',
-     ':?',
-     ':a',
-     ':*',
-     ('quote', 'bcd', {':str': True}),
-     ':?',
-     ('opearator..mul', 2, 3))
+    >>> (('lambda', (':', ':*', 'xAUTO0_'), 'xAUTO0_'),
+    ...  ':',
+    ...  ':?',
+    ...  ':a',
+    ...  ':*',
+    ...  ('quote', 'bcd', {':str': True}),
+    ...  ':?',
+    ...  ('opearator..mul', 2, 3))
+    (('lambda', (':', ':*', 'xAUTO0_'), 'xAUTO0_'), ':', ':?', ':a', ':*', ('quote', 'bcd', {':str': True}), ':?', ('opearator..mul', 2, 3))
 
 
 So you see, templates are not doing anything new.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -631,7 +631,7 @@ and the reader embeds the resulting object into the output Hissp::
 
     #> builtins..float#inf
     >>> __import__('pickle').loads(  # inf
-    ...     b'\x80\x03G\x7f\xf0\x00\x00\x00\x00\x00\x00.'
+    ...     b'Finf\n.'
     ... )
     inf
 
@@ -654,7 +654,7 @@ If you need more than one argument for a reader macro, use the built in
     #> .#(fractions..Fraction 1 2)
     #..
     >>> __import__('pickle').loads(  # Fraction(1, 2)
-    ...     b'\x80\x03cfractions\nFraction\nX\x03\x00\x00\x001/2\x85R.'
+    ...     b'cfractions\nFraction\n(V1/2\ntR.'
     ... )
     Fraction(1, 2)
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,6 @@ setuptools.setup(
         "Operating System :: POSIX",
         "Operating System :: Unix",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Topic :: Software Development",
         "Topic :: Software Development :: Code Generators",
@@ -34,6 +33,6 @@ setuptools.setup(
     keywords="lisp macro metaprogramming compiler DSL AST transpiler emacs clojure scheme",
     packages=setuptools.find_packages("src"),
     package_dir={"": "src"},
-    python_requires=">=3.7",
+    python_requires=">=3.8",
     entry_points={"console_scripts": ["hissp=hissp.__main__:repl"]},
 )

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -198,13 +198,13 @@ class Compiler:
         For example,
 
         >>> readerless(
-        ... ('lambda', ('a','b',
+        ... ('lambda', ('a',':/','b',
         ...         ':', 'e',1, 'f',2,
         ...         ':*','args', 'h',4, 'i',':?', 'j',1,
         ...         ':**','kwargs',),
         ...   42,),
         ... )
-        '(lambda a,b,e=(1),f=(2),*args,h=(4),i,j=(1),**kwargs:(42))'
+        '(lambda a,/,b,e=(1),f=(2),*args,h=(4),i,j=(1),**kwargs:(42))'
 
         The special keywords :* and :** designate the remainder of the
         positional and keyword parameters, respectively.
@@ -226,9 +226,9 @@ class Compiler:
         Also note that the body can be empty.
 
         >>> readerless(
-        ... ('lambda', (':','a',1, ':*',':?', 'b',':?', 'c',2,),),
+        ... ('lambda', (':','a',1, ':/',':?', ':*',':?', 'b',':?', 'c',2,),),
         ... )
-        '(lambda a=(1),*,b,c=(2):())'
+        '(lambda a=(1),/,*,b,c=(2):())'
 
         The ':' may be omitted if there are no paired parameters.
 
@@ -255,10 +255,12 @@ class Compiler:
     @trace
     def parameters(self, parameters: tuple) -> Iterable[str]:
         parameters = iter(parameters)
-        yield from takewhile(lambda a: a != ":", parameters)
+        yield from ('/' if a==':/' else a for a in takewhile(lambda a: a != ":", parameters))
         for k, v in pairs(parameters):
             if k == ":*":
                 yield "*" if v == ":?" else f"*{v}"
+            elif k == ":/":
+                yield "/"
             elif k == ":**":
                 yield f"**{v}"
             elif v == ":?":

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -15,7 +15,7 @@ quoted = (
     | st.integers()
     | st.floats(allow_nan=False)
     | st.complex_numbers(allow_nan=False)
-    | st.binary()  # bytes
+    | st.binary(max_size=17)  # bytes
 )
 literals = st.recursive(
     # strings, bytes, numbers, tuples, lists, dicts, sets, booleans, and None
@@ -24,6 +24,7 @@ literals = st.recursive(
     | st.sets(quoted)
     | st.builds(tuple, st.lists(children))
     | st.dictionaries(quoted, children),
+    max_leaves=17
 )
 
 


### PR DESCRIPTION
Text-mode pickles by defualt, pretty-printed literals, and positional-only arguments. Hissp now requires Python 3.8 to run the compiler. (But the compiled output can still run on older versions, if you're careful.)