### PR TITLE
Backslashes in atoms

### DIFF
--- a/docs/lex.py
+++ b/docs/lex.py
@@ -23,11 +23,11 @@ class LisspLexer(RegexLexer):
             (r';.*', pt.Comment),
             (r'[\n ]+', pt.Whitespace),
             (r'\s|\r', pt.Error),
-            (r''',@|['`,]''', pt.Operator),
-            (r'''(?:[^ \n"(){}[\]#]*[#])''', pt.Operator.Word),
+            (r''',@|['`,]|$#|.#|_#''', pt.Operator),
+            (r'''(?:[^\\ \n"();#]|\\.)+[#]''', pt.Operator.Word),
 
             # Python numbers
-            (r'False|True', pt.Number.Integer),
+            (r'False|True', pt.Name.Builtin),
             (rf'{SN}{Ds}(?:\.{Ds}?{Es}?[Jj]?|{Es}[Jj]?|[Jj])', pt.Number.Float),
             (rf'{SN}\.{Ds}{Es}?[Jj]?', pt.Number.Float),
             (rf'{SN}?0[oO](?:_?[0-7])+', pt.Number.Oct),
@@ -38,8 +38,8 @@ class LisspLexer(RegexLexer):
             ('None|\.\.\.', pt.Name.Builtin),
             (r':[^ \n"()]*', pt.String.Symbol),  # :control-words
 
-            (r'''[[{][^ \n"()]*''', pt.Literal),
-            (r'''[^ \n"()]+''', pt.Name.Variable),
+            (r'''[[{](:?[^\\ \n"();]|\\.)*''', pt.Literal),
+            (r'''(:?[^\\ \n"();]|\\.)+''', pt.Name.Variable),
         ]
     }
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -402,11 +402,11 @@ as an identifier and as a string representing that identifier:
     #..
     >>> setattr(
     ...   spam,
-    ...   'xBANG_xAT_xPERCENT_xDOLLAR_',
+    ...   'xBANG_xAT_xPCENT_xDOLR_',
     ...   'eggs')
 
     #> spam.!@%$
-    >>> spam.xBANG_xAT_xPERCENT_xDOLLAR_
+    >>> spam.xBANG_xAT_xPCENT_xDOLR_
     'eggs'
 
 Control Words

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -369,10 +369,10 @@ Symbols have another important difference from double-quoted strings:
     >>> 'foo->bar?'
     'foo->bar?'
 
-Symbols may contain symbol characters,
+Symbols may contain special characters,
 but the Python identifiers they represent cannot.
-Therefore, the reader *munges* symbols with symbol characters into
-valid identifier strings by using ``xQUOTEDxWORDS_``.
+Therefore, the reader *munges* symbols with forbidden characters
+to valid identifier strings by using ``xQUOTEDxWORDS_``.
 
 This format was chosen because it contains an underscore
 and both lower-case and upper-case letters,
@@ -408,6 +408,43 @@ as an identifier and as a string representing that identifier:
     #> spam.!@%$
     >>> spam.xBANG_xAT_xPCENT_xDOLR_
     'eggs'
+
+
+Spaces, double quotes, parentheses, and semicolons are allowed in symbols,
+but they must each be escaped with a backslash to prevent it from terminating the symbol.
+(Escape a backslash with another backslash.)
+
+.. code-block:: Lissp
+
+    #> 'embedded\ space
+    >>> 'embeddedxSPACE_space'
+    'embeddedxSPACE_space'
+
+Python does not allow some characters to start an identifier that it allows inside identifiers,
+such as digits.
+You also have to escape these if they begin a symbol to distinguish them from numbers.
+
+.. code-block:: Lissp
+
+    #> '\108
+    >>> 'xDIGITxONE_08'
+    'xDIGITxONE_08'
+
+Notice that only the first digit had to be munged to make it a valid Python identifier.
+
+The munger also normalizes unicode symbols to NFKC,
+because Python already does this when converting identifiers to strings:
+
+>>> ascii_a = 'A'
+>>> unicode_a = '𝐀'
+>>> ascii_a == unicode_a
+False
+>>> import unicodedata
+>>> ascii_a == unicodedata.normalize('NFKC', unicode_a)
+True
+>>> 𝐀 = unicodedata.name(unicode_a)
+>>> globals()[ascii_a]
+'MATHEMATICAL BOLD CAPITAL A'
 
 Control Words
 ~~~~~~~~~~~~~
@@ -900,8 +937,8 @@ as well. E.g. ``_hissxAUTO42_``. Try it.)
 Gensyms are mainly used to prevent accidental name collisions in generated code,
 which is very important for reliable macros.
 
-Atomic Literal Data Structures
-------------------------------
+Collection Atoms
+----------------
 
 A subset of Python's data structure notation works in Lissp as well:
 
@@ -943,19 +980,18 @@ Since they normally represent code,
 you must quote them to use them as data.
 
 .. Caution::
-   Unlike Python's data structure notation,
-   double quotes, parentheses, spaces, and newlines
-   are **not** allowed anywhere in Lissp's atomic data structures,
-   even in nested strings, because this causes them to be read as multiple forms.
+   To keep the grammar simple, spaces, double quotes, parentheses, and semicolons
+   in collection atoms must be escaped with a backslash, even in nested strings.
 
-   While a significantly more complex reader could distinguish these cases (as Python does),
+   While a significantly more complex reader could distinguish these cases without escapes
+   (as Python does),
    Lissp doesn't really need this capability because it can already read in arbitrary
    Python expressions using the inject macro ``.#``.
-   The literals are just a convenience notation for simple cases.
+   The collection atoms are just a convenience notation for simple cases.
 
 Unlike Python's notation,
-atomic data structures in Lissp may contain only static values discernible at read time.
-A literal data structure is read as a *single atom*.
+because these collections are read in as a *single atom*,
+they may contain only static values discernible at read time.
 If you want to interpolate runtime data,
 use function calls and templates instead:
 

--- a/src/hissp/munger.py
+++ b/src/hissp/munger.py
@@ -2,10 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import re
+import unicodedata
 from contextlib import suppress
 from typing import Dict, Hashable, Mapping, Match, TypeVar
-
-import unicodedata
 
 
 def munge(s: str) -> str:
@@ -20,17 +19,25 @@ TO_NAME = {
     "!": "xBANG_",
     "@": "xAT_",
     "#": "xHASH_",
-    "$": "xDOLLAR_",
-    "%": "xPERCENT_",
+    "$": "xDOLR_",
+    "%": "xPCENT_",
     "^": "xCARET_",
     "&": "xET_",
     "*": "xSTAR_",
+    "(": "xPAREN_",
+    ")": "xTHESES_",
     "-": "xH_",  # Hyphen
     "+": "xPLUS_",
     "=": "xEQ_",
+    "{": "xCURLY_",
+    "[": "xSQUARE_",
+    "}": "xBRACES_",
+    "]": "xBRACKETS_",
     "|": "xBAR_",
     "\\": "xBSLASH_",
     ":": "xCOLON_",
+    ";": "xSCOLON_",
+    '"': "x2QUOTE_",
     "'": "xQUOTE_",
     "<": "xLT_",  # Less Than or LefT.
     ",": "xCOMMA_",

--- a/src/hissp/munger.py
+++ b/src/hissp/munger.py
@@ -6,57 +6,80 @@ import unicodedata
 from contextlib import suppress
 from typing import Dict, Hashable, Mapping, Match, TypeVar
 
-
 def munge(s: str) -> str:
-    if s.startswith(":") or s.isidentifier():
-        return s
-    return "".join(map(x_quote, s))
+    if s.startswith(":"):
+        return s  # control word
+    # Always normalize identifiers:
+    # >>> 𝐀 = 'MATHEMATICAL BOLD CAPITAL A'
+    # >>> 'A' in globals()
+    # True
+    s = unicodedata.normalize("NFKC", s)
+    if s.isidentifier():
+        return s  # Nothing to munge.
+    return ".".join(munge_part(part) for part in s.split('.'))
 
 
+def munge_part(part):
+    if part:
+        part = "".join(map(x_quote, part))
+        if not part.isidentifier():
+            part = force_x_quote(part[0]) + part[1:]
+            assert part.isidentifier(), f"{part!r} is not identifier"
+    return part
+
+
+# Shorter munging names for some ASCII characters.
 TO_NAME = {
-    "~": "xTILDE_",
-    "`": "xGRAVE_",
+    # ASCII control characters don't munge to names.
     "!": "xBANG_",
-    "@": "xAT_",
+    "\"": "x2QUOTE_",
     "#": "xHASH_",
     "$": "xDOLR_",
     "%": "xPCENT_",
-    "^": "xCARET_",
     "&": "xET_",
-    "*": "xSTAR_",
+    "'": "x1QUOTE_",
     "(": "xPAREN_",
     ")": "xTHESES_",
-    "-": "xH_",  # Hyphen
+    "*": "xSTAR_",
     "+": "xPLUS_",
-    "=": "xEQ_",
-    "{": "xCURLY_",
-    "[": "xSQUARE_",
-    "}": "xBRACES_",
-    "]": "xBRACKETS_",
-    "|": "xBAR_",
-    "\\": "xBSLASH_",
-    ":": "xCOLON_",
+    # xCOMMA_ is fine.
+    "-": "xH_",  # Hyphen-minus
+    # Full stop reserved for imports and attributes.
+    "/": "xSLASH_",
+    # Digits only munge if first character.
     ";": "xSCOLON_",
-    '"': "x2QUOTE_",
-    "'": "xQUOTE_",
     "<": "xLT_",  # Less Than or LefT.
-    ",": "xCOMMA_",
+    "=": "xEQ_",
     ">": "xGT_",  # Greater Than or riGhT.
     "?": "xQUERY_",
-    "/": "xSLASH_",
-    " ": "xSPACE_",
+    "@": "xAT_",
+    # Capital letters are always valid in Python identifiers.
+    "[": "xSQUARE_",
+    "\\": "xBSLASH_",
+    "]": "xBRACKETS_",
+    "^": "xCARET_",
+    # Underscore is valid in Python identifiers.
+    "`": "xGRAVE_",
+    # Small letters are also always valid.
+    "{": "xCURLY_",
+    "|": "xBAR_",
+    "}": "xBRACES_",
+    # xTILDE_ is fine.
 }
 X_NAME = {ord(k): ord(v) for k, v in {" ": "x", "-": "h"}.items()}
 
 
 def x_quote(c: str) -> str:
-    return (
-        TO_NAME.get(c)
-        or unicodedata.category(c) == "Sm"
-        and f"x{unicodedata.name(c).translate(X_NAME)}_"
-        or c
-    )
+    with suppress(LookupError):
+        return TO_NAME[c]
+    if ('x'+c).isidentifier():
+        return c
+    return force_x_quote(c)
 
+def force_x_quote(c: str) -> str:
+    with suppress(ValueError):
+        return f"x{unicodedata.name(c).translate(X_NAME)}_"
+    return f"x{ord(c)}_"
 
 K = TypeVar("K", bound=Hashable)
 V = TypeVar("V")
@@ -74,9 +97,11 @@ UN_X_NAME = reversed_1to1(X_NAME)
 
 def un_x_quote(match: Match[str]) -> str:
     with suppress(KeyError):
-        return LOOKUP_NAME.get(match.group()) or unicodedata.lookup(
-            match.group(1).translate(UN_X_NAME)
-        )
+        return LOOKUP_NAME[match.group()]
+    with suppress(KeyError):
+        return unicodedata.lookup(match.group(1).translate(UN_X_NAME))
+    with suppress(ValueError):
+        return chr(int(match.group(1)))
     return match.group()
 
 

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -38,9 +38,9 @@ TOKENS = re.compile(
    ,@
   |['`,]
    # Any atom that ends in (an unescaped) ``#``
-  |(?:[^\\ \n"()#]|\\.)+[#]
+  |(?:[^\\ \n"();#]|\\.)+[#]
  )
-|(?P<atom>(?:[^\\ \n"()]|\\.)+)  # Let Python deal with it.
+|(?P<atom>(?:[^\\ \n"();]|\\.)+)  # Let Python deal with it.
 """
 )
 
@@ -147,6 +147,7 @@ class Parser:
     @staticmethod
     def _atom(v):
         symbol = v[0] == '\\'
+        v = v.replace(r'\.', 'xFULLxSTOP_')
         v = re.sub(r'\\(.)', lambda m: m[1], v)
         if symbol:
             return munge(v)
@@ -182,6 +183,7 @@ class Parser:
             if is_string(form):
                 form = form[1]
             return reduce(getattr, function.split("."), import_module(module))(form)
+        # TODO: consider unqualified reader macros.
         raise ValueError(f"Unknown reader macro {tag}")
 
     def template(self, form):

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -24,7 +24,7 @@ TOKENS = re.compile(
  (?P<open>\()
 |(?P<close>\))
 |(?P<string>
-  b?  # bytes
+  b?  # bytes?
   "  # Open quote.
     (?:[^"\\]  # Any non-magic character.
        |\\(?:.|\n)  # Backslash only if paired, including with newline.
@@ -37,10 +37,10 @@ TOKENS = re.compile(
 |(?P<macro>
    ,@
   |['`,]
-   # Ends in ``#``, but not dict, set, list, str.
-  |(?:[^ \n"(){}[\]#]+[#])
+   # Any atom that ends in (an unescaped) ``#``
+  |(?:[^\\ \n"()#]|\\.)+[#]
  )
-|(?P<symbol>[^ \n"()]+)
+|(?P<atom>(?:[^\\ \n"()]|\\.)+)  # Let Python deal with it.
 """
 )
 
@@ -105,8 +105,8 @@ class Parser:
                 continue
             elif k == "macro":
                 yield from self._macro(tokens, v)
-            elif k == "symbol":
-                yield from self._symbol(v)
+            elif k == "atom":
+                yield self._atom(v)
             elif k == "badspace":
                 raise SyntaxError("Bad space: " + repr(k))
             else:
@@ -145,14 +145,18 @@ class Parser:
             yield self.parse_macro(v, form)
 
     @staticmethod
-    def _symbol(v):
+    def _atom(v):
+        symbol = v[0] == '\\'
+        v = re.sub(r'\\(.)', lambda m: m[1], v)
+        if symbol:
+            return munge(v)
         try:
             val = ast.literal_eval(v)
             if isinstance(val, bytes):  # bytes have their own literals.
-                raise ValueError  # munge
-            yield val
+                return munge(v)
+            return val
         except (ValueError, SyntaxError):
-            yield munge(v)
+            return munge(v)
 
     def parse_macro(self, tag: str, form):
         if tag == "'":

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -24,7 +24,7 @@ literals = st.recursive(
     | st.sets(quoted)
     | st.builds(tuple, st.lists(children))
     | st.dictionaries(quoted, children),
-    max_leaves=6
+    max_leaves=5
 )
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -24,7 +24,7 @@ literals = st.recursive(
     | st.sets(quoted)
     | st.builds(tuple, st.lists(children))
     | st.dictionaries(quoted, children),
-    max_leaves=7
+    max_leaves=6
 )
 
 

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -48,7 +48,6 @@ class TestCompileGeneral(TestCase):
 
     @given(
         st.characters(
-            blacklist_characters='(){}[];".',
             whitelist_categories=["Lu", "Ll", "Lt", "Nl", "Sm"],
         )
     )

--- a/tests/test_munger.py
+++ b/tests/test_munger.py
@@ -23,7 +23,7 @@ class TestMunger(TestCase):
             munger.munge(r"""~!@#$%^&*()_+{}|:"<>?`-=[]\;',./"""),
             "xTILDE_xBANG_xAT_xHASH_xDOLR_xPCENT_xCARET_xET_xSTAR_xPAREN_xTHESES_"
             "_xPLUS_xCURLY_xBRACES_xBAR_xCOLON_x2QUOTE_xLT_xGT_xQUERY_xGRAVE_xH_xEQ_"
-            "xSQUARE_xBRACKETS_xBSLASH_xSCOLON_xQUOTE_xCOMMA_.xSLASH_"
+            "xSQUARE_xBRACKETS_xBSLASH_xSCOLON_x1QUOTE_xCOMMA_.xSLASH_"
         )
 
     @given(st.text(st.characters(["Sm"]), min_size=1))

--- a/tests/test_munger.py
+++ b/tests/test_munger.py
@@ -1,6 +1,7 @@
 # Copyright 2019 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
 
+import unicodedata
 from unittest import TestCase
 
 import hypothesis.strategies as st
@@ -15,7 +16,7 @@ class TestMunger(TestCase):
         x = munger.munge(s)
         self.assertEqual(x, munger.munge(munger.demunge(x)))
         if "x" not in s:
-            self.assertEqual(s, munger.demunge(x))
+            self.assertEqual(unicodedata.normalize("NFKC", s), munger.demunge(x))
 
     def test_munge_basic(self):
         self.assertEqual(

--- a/tests/test_munger.py
+++ b/tests/test_munger.py
@@ -19,9 +19,10 @@ class TestMunger(TestCase):
 
     def test_munge_basic(self):
         self.assertEqual(
-            munger.munge(r"~!@#$%^&*+`-=|\:'<>?,/"),
-            "xTILDE_xBANG_xAT_xHASH_xDOLLAR_xPERCENT_xCARET_xET_xSTAR_xPLUS_xGRAVE_xH_"
-            "xEQ_xBAR_xBSLASH_xCOLON_xQUOTE_xLT_xGT_xQUERY_xCOMMA_xSLASH_",
+            munger.munge(r"""~!@#$%^&*()_+{}|:"<>?`-=[]\;',./"""),
+            "xTILDE_xBANG_xAT_xHASH_xDOLR_xPCENT_xCARET_xET_xSTAR_xPAREN_xTHESES_"
+            "_xPLUS_xCURLY_xBRACES_xBAR_xCOLON_x2QUOTE_xLT_xGT_xQUERY_xGRAVE_xH_xEQ_"
+            "xSQUARE_xBRACKETS_xBSLASH_xSCOLON_xQUOTE_xCOMMA_.xSLASH_"
         )
 
     @given(st.text(st.characters(["Sm"]), min_size=1))

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -115,9 +115,9 @@ r''''\~\!\@\#\$\%\^\&\*\(\)\_\+\{\}\|\:\"\<\>\?\`\-\=\[\]\\\;\'\,\.\/''':
       'xTILDE_xBANG_xAT_xHASH_xDOLR_xPCENT_xCARET_xET_xSTAR_xPAREN_xTHESES__xPLUS'
       '_xCURLY_xBRACES_xBAR_xCOLON_x2QUOTE_xLT_xGT_xQUERY_xGRAVE_xH_xEQ_xSQUARE'
       '_xBRACKETS_xBSLASH_xSCOLON_xQUOTE_xCOMMA_.xSLASH_')],
-r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\''':
-    ['x_1',
-     'x_12',
+r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \ ''':
+    ['xDIGITxONE_',
+     'xDIGITxONE_2',
      'xSQUARE_xBRACKETS_',
      'xPAREN_xTHESES_',
      'xCURLY_xBRACES_',
@@ -128,7 +128,8 @@ r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\''':
      'xCOMMA_',
      'xQUOTE_',
      'x2QUOTE_',
-     'xBSLASH_'],
+     'xBSLASH_',
+     'xSPACE_'],
 }
 
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -75,16 +75,16 @@ object.__class__.__name__ ; Attributes chain.
     ('quote', '', {':str': True}),
 ],
 '''b""''': [b''],
-"b''": ['bxQUOTE_xQUOTE_'],
-"b''''''": ['bxQUOTE_xQUOTE_xQUOTE_xQUOTE_xQUOTE_xQUOTE_'],
+"b''": ['bx1QUOTE_x1QUOTE_'],
+"b''''''": ['bx1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_'],
 '''b""""""''': [
     b'', ('quote', '', {':str': True}), ('quote', '', {':str': True})
 ],
 '''rb'' br'' RB'' BR'' rb"" br"" B"" ''': [
-    'rbxQUOTE_xQUOTE_',
-    'brxQUOTE_xQUOTE_',
-    'RBxQUOTE_xQUOTE_',
-    'BRxQUOTE_xQUOTE_',
+    'rbx1QUOTE_x1QUOTE_',
+    'brx1QUOTE_x1QUOTE_',
+    'RBx1QUOTE_x1QUOTE_',
+    'BRx1QUOTE_x1QUOTE_',
     'rb',
     ('quote', '', {':str': True}),
     'br',
@@ -114,7 +114,7 @@ r''''\~\!\@\#\$\%\^\&\*\(\)\_\+\{\}\|\:\"\<\>\?\`\-\=\[\]\\\;\'\,\.\/''':
     [('quote',
       'xTILDE_xBANG_xAT_xHASH_xDOLR_xPCENT_xCARET_xET_xSTAR_xPAREN_xTHESES__xPLUS'
       '_xCURLY_xBRACES_xBAR_xCOLON_x2QUOTE_xLT_xGT_xQUERY_xGRAVE_xH_xEQ_xSQUARE'
-      '_xBRACKETS_xBSLASH_xSCOLON_xQUOTE_xCOMMA_.xSLASH_')],
+      '_xBRACKETS_xBSLASH_xSCOLON_x1QUOTE_xCOMMA_xFULLxSTOP_xSLASH_')],
 r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \ ''':
     ['xDIGITxONE_',
      'xDIGITxONE_2',
@@ -126,7 +126,7 @@ r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \ ''':
      'xHASH_',
      'xGRAVE_',
      'xCOMMA_',
-     'xQUOTE_',
+     'x1QUOTE_',
      'x2QUOTE_',
      'xBSLASH_',
      'xSPACE_'],

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -110,6 +110,25 @@ newlines"
 (lambda (a b c)
   .#"(-b + (b**2 - 4*a*c)**0.5)/(2*a)")
 ''': [('lambda', ('a', 'b', 'c'), '(-b + (b**2 - 4*a*c)**0.5)/(2*a)')],
+r''''\~\!\@\#\$\%\^\&\*\(\)\_\+\{\}\|\:\"\<\>\?\`\-\=\[\]\\\;\'\,\.\/''':
+    [('quote',
+      'xTILDE_xBANG_xAT_xHASH_xDOLR_xPCENT_xCARET_xET_xSTAR_xPAREN_xTHESES__xPLUS'
+      '_xCURLY_xBRACES_xBAR_xCOLON_x2QUOTE_xLT_xGT_xQUERY_xGRAVE_xH_xEQ_xSQUARE'
+      '_xBRACKETS_xBSLASH_xSCOLON_xQUOTE_xCOMMA_.xSLASH_')],
+r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\''':
+    ['x_1',
+     'x_12',
+     'xSQUARE_xBRACKETS_',
+     'xPAREN_xTHESES_',
+     'xCURLY_xBRACES_',
+     'xSQUARE_xBRACKETS_',
+     'xSCOLON_',
+     'xHASH_',
+     'xGRAVE_',
+     'xCOMMA_',
+     'xQUOTE_',
+     'x2QUOTE_',
+     'xBSLASH_'],
 }
 
 


### PR DESCRIPTION
The catch-all token is now called "atom". Terminating characters in symbols and identifiers can now be escaped with a backslash to continue the symbol. This has the bonus effect of allowing these characters in the Python collection atoms, when escaped.

This also cleans up some faulty munger logic for unicode edge cases.

Escaped dots munge. Symbols can start with an escaped digit, which also munges.