### PR TITLE
No macro dependency

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -812,14 +812,31 @@ But you can still import things the same way Python does.
 How do I import a macro?
 ------------------------
 
-The same way you import anything else. Put it in the ``_macro_``
-namespace if you want it to be an active module-local macro. The
-compiler doesn't care how it gets there, but there's a nice
-`hissp.basic.._macro_.from-require<fromxH_require>` macro if you want to use that.
-
-Rather than importing macros,
-consider using a reader macro to abbreviate their qualified identifiers.
+The same way you import anything else: with a qualified identifier.
+In Lissp, you can use a reader macro to abbreviate qualifiers.
 `hissp.basic.._macro_.alias` can define these for you.
+
+Any callable in the current module's ``_macro_`` namespace will work unqualified.
+Normally you create these with `hissp.basic.._macro_.defmacro<defmacro>`,
+but the compiler doesn't care how they get there.
+
+Importing the ``_macro_`` namespace from another module will work,
+but then uses of `hissp.basic.._macro_.defmacro<defmacro>` will mutate
+another module's ``_macro_`` namespace, which is probably not what you want,
+so make a copy, or or make a new one and insert individual macros into it.
+
+The basic macros have no dependencies on the Hissp package in their expansions,
+which allows you to use their compiled output on another Python that doesn't have Hissp installed.
+However, if you import a ``_macro_`` at runtime,
+you're creating a runtime dependency on whatever module you import it from.
+
+The `hissp.basic.._macro_.prelude<prelude>` macro will clone the basic macro namespace
+only if available. It avoids creating a runtime dependency this way.
+
+`hissp.basic.._macro_.prelude<prelude>` is a convenience for short scripts,
+especially those used as the main module.
+Larger projects should probably be more explicit in their imports,
+and may need a more complete macro library anyway.
 
 How do I write a macro?
 -----------------------

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -460,8 +460,6 @@ Lissp Quick Start
    ;; and star imports from operator and itertools.
    (b/#prelude)
 
-   (require-as hissp.basic.._macro_.progn begin) ;Add an unqualified macro under a new name.
-
    ;;; definition
 
    (define answer 42)                     ;Add a global.

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -448,15 +448,18 @@ Lissp Quick Start
 
    ;;;; Basic Macros
 
-   _#" The REPL comes with some basic macros defined in hissp.basic.
-   By default, they don't work in .lissp files unqualified. But you can add
-   them to the current module's _macro_ namespace. The compiled output from
-   these does not require hissp to be installed."
+   _#" The REPL comes with some basic macros defined in hissp.basic. By default,
+   they don't work in .lissp files unqualified. The compiled output from these
+   does not require hissp to be installed."
 
-   ;;; macro import
+   ;; Makes a new reader macro to abbreviate a qualifier.
+   (hissp.basic.._macro_.alias b/ hissp.basic.._macro_.)
+   'b/#alias                              ;Now short for 'hissp.basic.._macro_.alias'.
 
-   (hissp.basic.._macro_.from-require
-     (hissp.basic define defmacro let))   ;Add unqualified macros to the current module.
+   ;; Imports a copy of hissp.basic.._macro_ (if available)
+   ;; and star imports from operator and itertools.
+   (b/#prelude)
+
    (require-as hissp.basic.._macro_.progn begin) ;Add an unqualified macro under a new name.
 
    ;;; definition

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -533,8 +533,8 @@ Lissp Quick Start
      (when (eq x 0)                       ;Conditional with side-effects, but no alternative.
        (print "In when")
        (print "was zero"))
-     (when-not (eq x 0)
-       (print "In when-not")
+     (unless (eq x 0)
+       (print "In unless")
        (print "wasn't zero")))
 
    ;; Shortcutting logical and.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -736,14 +736,17 @@ This inserts an actual ``inf`` object at read time into the Hissp code.
 Since this isn't a valid literal, it has to compile to a pickle.
 You should normally try to avoid emitting pickles
 (e.g. use ``(float 'inf)`` or `math..inf <math.inf>` instead),
-but note that a macro would get the original object,
+but note that another macro would get the original object,
 since the code hasn't been compiled yet, which may be useful.
 While unpickling does have some overhead,
 it may be worth it if constructing the object normally has even more.
 Naturally, the object must be picklable to emit a pickle.
 
-Unqualified reader macros are reserved for the basic Hissp reader.
-There are currently three of them: Inject ``.#``, discard ``_#``, and gensym ``$#``.
+Reader macros can also be unqualified.
+These three macros are built into the reader:
+Inject ``.#``, discard ``_#``, and gensym ``$#``.
+The reader also will check the current module's ``_macro_`` namespace (if it has one)
+when it encounters and unqualified macro name.
 
 If you need more than one argument for a reader macro, use the built-in
 inject ``.#`` macro, which evaluates a form at read time:

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -150,6 +150,45 @@ judicious use can improve performance and maintainability.
 
 ;; see also from bootstrap: let
 
+;;; linked-list emulation
+
+_#" Hissp is based on tuples rather than linked lists,
+but many macros still require this kind of recursive list processing.
+"
+
+(defmacro car (sequence)
+  "The first item of a sequence."
+  `(operator..getitem ,sequence 0))
+
+(defmacro cdr (sequence)
+  "Slice of the sequence without the first item."
+  `(operator..getitem ,sequence (slice 1 None)))
+
+(defmacro caar (xss)
+  "The first item of the first item. Short for ``(car (car xss))``."
+  `(car (car ,xss)))
+
+(defmacro cdar (xss)
+  "The slice of the first item without its first item.
+
+  Short for ``(cdr (car xss))``.
+  "
+  `(cdr (car ,xss)))
+
+(defmacro cadr (sequence)
+  "The second item of a sequence.
+
+  Like ``(car (cdr sequence))``, but more efficient.
+  "
+  `(operator..getitem ,sequence 1))
+
+(defmacro cddr (sequence)
+  "Slice of the sequence without the first two items.
+
+  Like ``(cdr (cdr sequence))``, but more efficient.
+  "
+  `(operator..getitem ,sequence (slice 2 None)))
+
 ;;; configuration
 
 (defmacro attach (target : :* args)
@@ -220,45 +259,6 @@ judicious use can improve performance and maintainability.
     expr))
 
 ;; TODO: implement other arrange macros?
-
-;;; linked-list emulation
-
-_#" Hissp is based on tuples rather than linked lists,
-but many macros still require this kind of recursive list processing.
-"
-
-(defmacro car (sequence)
-  "The first item of a sequence."
-  `(operator..getitem ,sequence 0))
-
-(defmacro cdr (sequence)
-  "Slice of the sequence without the first item."
-  `(operator..getitem ,sequence (slice 1 None)))
-
-(defmacro caar (xss)
-  "The first item of the first item. Short for ``(car (car xss))``."
-  `(car (car ,xss)))
-
-(defmacro cdar (xss)
-  "The slice of the first item without its first item.
-
-  Short for ``(cdr (car xss))``.
-  "
-  `(cdr (car ,xss)))
-
-(defmacro cadr (sequence)
-  "The second item of a sequence.
-
-  Like ``(car (cdr sequence))``, but more efficient.
-  "
-  `(operator..getitem ,sequence 1))
-
-(defmacro cddr (sequence)
-  "Slice of the sequence without the first two items.
-
-  Like ``(cdr (cdr sequence))``, but more efficient.
-  "
-  `(operator..getitem ,sequence (slice 2 None)))
 
 ;;; control flow
 

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -98,9 +98,9 @@ judicious use can improve performance and maintainability.
   "Evaluates the body when condition is true."
   `(if-else ,condition (progn ,@body) ()))
 
-(defmacro when-not (condition : :* body)
-  "``when-not`` Evaluates the body when condition is not true."
-  `(when (operator..not_ ,condition) ,@body))
+(defmacro unless (condition : :* body)
+  "Evaluates the body unless condition is true."
+  `(if-else ,condition () (progn ,@body)))
 
 (defmacro let (pairs : :* body)
   "Creates locals. Pairs are implied. Locals are not in scope until the body."
@@ -122,7 +122,7 @@ judicious use can improve performance and maintainability.
   "
   (let ($fn `$#fn)
     (let (fn `(lambda ,parameters ,docstring ,@body)
-          ns (when-not (operator..contains (.get hissp.compiler..NS) '_macro_)
+          ns (unless (operator..contains (.get hissp.compiler..NS) '_macro_)
                `((operator..setitem (globals) ','_macro_ (types..ModuleType ','_macro_))))
           dc (when (hissp.reader..is_string docstring)
                `((setattr ,$fn ','__doc__ ,docstring)))
@@ -324,7 +324,7 @@ the forward declaration.
 
 ;; TODO: implement case macro?
 
-;; see also from bootstrap: if-else, when, when-not
+;; see also from bootstrap: if-else, when, unless
 
 ;;; side effect
 

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -60,48 +60,14 @@ and judicious use can improve performance and maintainability.
 ;; Bootstrap macro namespace using builtins.
 (operator..setitem (globals) '_macro_ (types..ModuleType '_macro_))
 
-;; Define require-as macro.
-(setattr _macro_ 'require-as
-         (lambda (macro name)
-           `(builtins..setattr
-             (.setdefault (builtins..globals)
-                          ','_macro_
-                          (types..ModuleType "_macro_"))
-             (quote ,name)
-             ,macro)))
-(setattr _macro_.require-as '__doc__ "
-``requrie-as``
-Require a macro callable as an unqualified name.
-
-Adds the macro to the current module's _macro_ space under the specified
-name, which makes it available unqualified in this module. (And
-available qualified with this module's name.)
-")
-(setattr _macro_.require-as '__qualname__ '_macro_.require-as)
-
-;; Bootstrap enough of defmacro to def the 'defmacro' macro. Dawg.
-(require-as (lambda (name parameters : :* body)
-              `(require-as (lambda ,parameters ,@ body)
-                           ,name))
-            defmacro)
-
-(defmacro defmacro (name parameters : docstring ()  :* body)
-  `(require-as ((lambda ($#macro)  ; We don't have let yet.
-                  ;; Save docstring if available.
-                  (setattr $#macro
-                           ','__doc__
-                           ,(operator..getitem `(None ,docstring)
-                                               (hissp.reader..is_string docstring)))
-                  ;; Save qualified name.
-                  (setattr $#macro ','__qualname__ (.join "." '(,'_macro_ ,name)))
-                  $#macro)
-                ;; Create macro function.
-                (lambda ,parameters ,docstring ,@body))
-               ,name))
-(setattr _macro_.defmacro '__doc__ "
-Creates a new macro for the current module.
-")
-(setattr _macro_.defmacro '__qualname__ '_macro_.defmacro)
+;; Bootstrap enough of defmacro to defmacro the 'defmacro' macro. Dawg.
+(setattr _macro_
+         'defmacro
+         (lambda (name parameters docstring : :* body)
+           `((lambda ($#G (lambda ,parameters ,@body))
+               (setattr $#G ','__doc__ ,docstring)
+               (setattr $#G ','__qualname__ (.join "." '(,'_macro_ ,name)))
+               (setattr _macro_ ',name $#G)))))
 
 (defmacro let (pairs : :* body)
   "Creates locals. Pairs are implied. Locals are not in scope until the body."
@@ -331,3 +297,17 @@ except ModuleNotFoundError:
   `(defmacro ,alias ($#G)
      ',(.format "Aliases {} as {}#" module alias)
      (.format "{}{}" ',module $#G)))
+
+(defmacro defmacro (name parameters : docstring () :* body)
+  (let ($G `$#G
+        fn `(lambda ,parameters ,docstring ,@body)
+        ns (when (operator..not_in '_macro_ (.get hissp.compiler.NS))
+             `((operator..setitem (globals) ','_macro_ (types..ModuleType ','_macro_))))
+        dc (when (hissp.reader..is_string docstring)
+             `((setitem ,$G ','__doc__ ,docstring)))
+        qn `(setattr ,$G ','__qualname__ (.join "." '(,'_macro_ ,name))))
+    `(let (,$G ,fn)
+       ,@ns
+       ,@dc
+       ,qn
+       (setattr _macro_ ',name ,$G))))

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -58,12 +58,14 @@ forget about Hissp. Nevertheless, text substitution is available, and
 judicious use can improve performance and maintainability.
 "
 
+;;;; Bootstrap Macros
+
 ;; Bootstrap macro namespace using builtins.
 (operator..setitem (globals) '_macro_ (types..ModuleType '_macro_))
 
 ;; Bootstrap enough macros to define the 'defmacro' macro. Dawg.
 
-;; Simplified bootstrap version.
+;; Simplified bootstrap version assumes ideal conditions to avoid branching.
 (setattr _macro_
          'defmacro
          (lambda (name parameters docstring : :* body)
@@ -105,6 +107,10 @@ judicious use can improve performance and maintainability.
   `((lambda (: ,@pairs)
       ,@body)))
 
+;;;; Post-bootstrap
+
+;;; definition
+
 ;; Define the real defmacro using the bootstrap macros.
 (defmacro defmacro (name parameters : docstring () :* body)
   "Creates a new macro for the current module.
@@ -126,6 +132,96 @@ judicious use can improve performance and maintainability.
          ,@dc
          ,qn
          (setattr ,'_macro_ ',name ,$fn)))))
+
+(defmacro define (name value)
+  "Assigns a global in the current module."
+  `(operator..setitem (builtins..globals)
+                      ',name
+                      ,value))
+
+(defmacro deftype (name bases : :* body)
+  "Defines a type (class) in the current module.
+
+  Key-value pairs are implied in the body.
+  "
+  `(define ,name
+       (type ',name ((lambda (: :* xAUTO0_) xAUTO0_) ,@bases)
+             (dict : ,@body))))
+
+;; see also from bootstrap: let
+
+;;; configuration
+
+(defmacro attach (target : :* args)
+  "Attaches the named variables as attributes of the target.
+
+  Positional arguments use the same name as the variable.
+  Names after the ``:`` are key-value pairs.
+  "
+  (let (iargs (iter args)
+              $target `$#target)
+    (let (args (itertools..takewhile (lambda (a)
+                                       (operator..ne a ':))
+                                     iargs))
+      `(let (,$target ,target)
+         ,@(map (lambda (arg)
+                  `(setattr ,$target ',arg ,arg))
+                args)
+         ,@(map (lambda (kw)
+                  `(setattr ,$target ',kw ,(next iargs)))
+                iargs)
+         ,$target))))
+
+(defmacro cascade (thing : :* calls)
+  "Call multiple methods on one object.
+
+  Evaluates the given thing then uses it as the first argument to a
+  sequence of calls. Used for initialization. Evaluates to the thing.
+  "
+  (let ($thing `$#thing)
+    `((lambda (: ,$thing ,thing)
+        ,@(map (lambda (call)
+                 `(,(car call)
+                   ,$thing
+                   ,@(cdr call)))
+               calls)
+        ,$thing))))
+
+;;; threading
+
+(defmacro -> ())
+(defmacro -> (expr : :* forms)
+  "``->`` 'Thread-first'.
+
+  Converts a pipeline to function calls by recursively threading it as
+  the first argument of the next form.
+  E.g. ``(-> x (A b) (C d e))`` is ``(C (A x b) d e)``
+  Makes chained method calls easier to read.
+  "
+  (if-else forms
+    `(-> (,(caar forms) ,expr ,@(cdar forms))
+         ,@(cdr forms))
+    expr))
+
+(defmacro ->> ())
+(defmacro ->> (expr : :* forms)
+  "``->>`` 'Thread-last'.
+
+  Converts a pipeline to function calls by recursively threading it as
+  the last argument of the next form.
+  E.g. ``(->> x (A b) (C d e))`` is ``(C d e (A b x))``.
+  Can replace partial application in some cases.
+  Also works inside a ``->`` pipeline.
+  E.g. ``(-> x (A a) (->> B b) (C c))`` is ``(C (B b (A x a)) c)``.
+  "
+  (if-else forms
+    `(->> (,@(car forms) ,expr)
+          ,@(cdr forms))
+    expr))
+
+;; TODO: implement other arrange macros?
+
+;;; linked-list emulation
 
 _#" Hissp is based on tuples rather than linked lists,
 but many macros still require this kind of recursive list processing.
@@ -164,26 +260,7 @@ but many macros still require this kind of recursive list processing.
   "
   `(operator..getitem ,sequence (slice 2 None)))
 
-(defmacro cascade (thing : :* calls)
-  "Call multiple methods on one object.
-
-  Evaluates the given thing then uses it as the first argument to a
-  sequence of calls. Used for initialization. Evaluates to the thing.
-  "
-  (let ($thing `$#thing)
-    `((lambda (: ,$thing ,thing)
-        ,@(map (lambda (call)
-                 `(,(car call)
-                   ,$thing
-                   ,@(cdr call)))
-               calls)
-        ,$thing))))
-
-(defmacro define (name value)
-  "Assigns a global in the current module."
-  `(operator..setitem (builtins..globals)
-                      ',name
-                      ,value))
+;;; control flow
 
 _#"``cond`` is recursive.
 
@@ -245,6 +322,12 @@ the forward declaration.
                        (|| ,@rest)))
            first))
 
+;; TODO: implement case macro?
+
+;; see also from bootstrap: if-else, when, when-not
+
+;;; side effect
+
 (defmacro prog1 (expr1 : :* body)
   "Evaluates each expression in sequence (for side effects),
   resulting in the value of the first."
@@ -252,68 +335,12 @@ the forward declaration.
      ,@body
      $#value1))
 
-(defmacro deftype (name bases : :* body)
-  "Defines a type (class) in the current module.
+;; see also from bootstrap: progn
 
-  Key-value pairs are implied in the body.
-  "
-  `(define ,name
-       (type ',name ((lambda (: :* xAUTO0_) xAUTO0_) ,@bases)
-             (dict : ,@body))))
+;; Note that any of the basic macros with a lambda "body" argument
+;; also sequence expressions for side effects.
 
-(defmacro attach (target : :* args)
-  "Attaches the named variables as attributes of the target.
-
-  Positional arguments use the same name as the variable.
-  Names after the ``:`` are key-value pairs.
-  "
-  (let (iargs (iter args)
-              $target `$#target)
-    (let (args (itertools..takewhile (lambda (a)
-                                       (operator..ne a ':))
-                                     iargs))
-      `(let (,$target ,target)
-         ,@(map (lambda (arg)
-                  `(setattr ,$target ',arg ,arg))
-                args)
-         ,@(map (lambda (kw)
-                  `(setattr ,$target ',kw ,(next iargs)))
-                iargs)
-         ,$target))))
-
-;; TODO: implement case macro?
-
-(defmacro -> ())
-(defmacro -> (expr : :* forms)
-  "``->`` 'Thread-first'.
-
-  Converts a pipeline to function calls by recursively threading it as
-  the first argument of the next form.
-  E.g. ``(-> x (A b) (C d e))`` is ``(C (A x b) d e)``
-  Makes chained method calls easier to read.
-  "
-  (if-else forms
-    `(-> (,(caar forms) ,expr ,@(cdar forms))
-         ,@(cdr forms))
-    expr))
-
-(defmacro ->> ())
-(defmacro ->> (expr : :* forms)
-  "``->>`` 'Thread-last'.
-
-  Converts a pipeline to function calls by recursively threading it as
-  the last argument of the next form.
-  E.g. ``(->> x (A b) (C d e))`` is ``(C d e (A b x))``.
-  Can replace partial application in some cases.
-  Also works inside a ``->`` pipeline.
-  E.g. ``(-> x (A a) (->> B b) (C c))`` is ``(C (B b (A x a)) c)``.
-  "
-  (if-else forms
-    `(->> (,@(car forms) ,expr)
-          ,@(cdr forms))
-    expr))
-
-;; TODO: implement other arrange macros?
+;;; import
 
 (defmacro prelude ()
   "Grants unqualified access to the basics.

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -1,7 +1,6 @@
 ;; Copyright 2019, 2020 Matthew Egan Odendahl
 ;; SPDX-License-Identifier: Apache-2.0
-"
-Hissp's basic macros.
+" Hissp's basic macros.
 
 These are automatically made available as unqualified macros in the
 basic REPL. To use them in a Hissp module, use the ``prelude`` macro or
@@ -10,51 +9,53 @@ fully-qualified names. You can abbreviate qualifiers with reader macros:
 .. code-block:: Lissp
 
   (hissp.basic.._macro_.alias b/ hissp.basic.._macro_.)
-  (b/#define foo 2)                    ;Same as (hissp.basic.._macro_.define foo 2)
+  ;; Now the same as (hissp.basic.._macro_.define foo 2).
+  (b/#define foo 2)
 
 The basic macros are deliberately restricted in design.
 
 They have NO DEPENDENCIES in their expansions;
 they use only the standard library with no extra helper functions.
-This means that the compiled code does not require hissp to be installed to work,
-but all helper code must be inlined,
-resulting in larger expansions.
+This means that the compiled code does not require Hissp to be installed
+to work, but all helper code must be inlined, resulting in larger
+expansions than might otherwise be necessary.
 
-They also have no prerequisite initialization,
-beyond what is available in a standard Python module.
-Their Python compilation would work directly in an ``exec()``.
-For example, a ``_macro_`` namespace need not be available for ``defmacro``.
-The inlined helper code in each expansion will do that initialization for you, if necessary.
+They also have no prerequisite initialization, beyond what is available
+in a standard Python module. Their Python compilation would work
+directly in an ``exec()``. For example, a ``_macro_`` namespace need not
+be available for ``defmacro``. It's smart enough to check for the
+presence of ``_macro_`` in its expanson context, and inline the
+initialization code when required.
 
-They also eschew text substitutions,
-relying only on the built-in special forms ``quote`` and ``lambda``,
-which makes their expansions compatible with advanced rewriting macros that process the expansions of other macros.
+With the exception of ``prelude`` (which is only meant for the top
+level), they also eschew text substitutions, relying only on the
+built-in special forms ``quote`` and ``lambda``, which makes their
+expansions compatible with advanced rewriting macros that process the
+expansions of other macros.
 
-To help keep macros and their expansions manageable in size,
-these basic macros lack some of the advanced bells and whistles that their equivalents have in Python or other Lisps.
+To help keep macros and their expansions manageable in size, these basic
+macros lack some of the advanced bells and whistles that their
+equivalents have in Python or other Lisps.
 "
 
-_#"
-This module is not necessarily a good example of how you should write Lissp or Lissp macros.
-Besides the design restrictions mentioned in the module docstring above,
-the macros defined here were not available at the start,
-so the early ones had to be bootstrapped without them, often in awkward ways.
+_#" This module is not necessarily a good example of how you should
+write Lissp or Lissp macros. Besides the design restrictions mentioned
+in the module docstring above, the macros defined here were not
+available at the start, so some had to be bootstrapped without the
+benefit of a complete macro suite.
 
-These macros don't create compiled dependencies on hissp,
-but that doesn't mean you can't depend on your own code.
-Hissp's qualified symbols,
-and Lissp's template syntax that automatically creates them,
-are there to make helper functions easy to use in macroexpansions.
-Use them.
+These macros don't create compiled dependencies on Hissp, but that
+doesn't mean you can't depend on your own code. Hissp's qualified
+symbols, and Lissp's template syntax that automatically creates them,
+are there to make helper functions easy to use in macroexpansions. Use
+them.
 
-However, the restriction on text-substitution is still recommended.
-Many useful advanced macros must process the expansion of other macros,
-but they require syntax trees to work on.
-Text hides that structure.
-If you want to go that route,
-you might as well use `ast` and ``exec()` and forget about Hissp.
-Nevertheless, text substitution is available,
-and judicious use can improve performance and maintainability.
+However, the restriction on text-substitution is still recommended. Many
+useful advanced macros must process the expansion of other macros, but
+they require syntax trees to work on. Text hides that structure. If you
+want to go that route, you might as well use `ast` and ``exec()` and
+forget about Hissp. Nevertheless, text substitution is available, and
+judicious use can improve performance and maintainability.
 "
 
 ;; Bootstrap macro namespace using builtins.
@@ -72,10 +73,9 @@ and judicious use can improve performance and maintainability.
                (setattr _macro_ ',name $#G)))))
 
 (defmacro if-else (test then otherwise)
-  "``if-else``
-  Basic ternary branching construct.
+  "``if-else`` Basic ternary branching construct.
 
-  Like Python's conditional expressions, the else-clause is required.
+  Like Python's conditional expressions, the 'else' clause is required.
   "
   `((lambda (,'test : :* ,'then-else)
       ((operator..getitem ,'then-else (operator..not_ ,'test))))
@@ -127,8 +127,7 @@ and judicious use can improve performance and maintainability.
          ,qn
          (setattr ,'_macro_ ',name ,$fn)))))
 
-_#"
-Hissp is based on tuples rather than linked lists,
+_#" Hissp is based on tuples rather than linked lists,
 but many macros still require this kind of recursive list processing.
 "
 
@@ -145,15 +144,24 @@ but many macros still require this kind of recursive list processing.
   `(car (car ,xss)))
 
 (defmacro cdar (xss)
-  "The slice of the first item without its first item. Short for ``(cdr (car xss))``."
+  "The slice of the first item without its first item.
+
+  Short for ``(cdr (car xss))``.
+  "
   `(cdr (car ,xss)))
 
 (defmacro cadr (sequence)
-  "The second item of a sequence. Like ``(car (cdr sequence))``, but more efficient."
+  "The second item of a sequence.
+
+  Like ``(car (cdr sequence))``, but more efficient.
+  "
   `(operator..getitem ,sequence 1))
 
 (defmacro cddr (sequence)
-  "Slice of the sequence without the first two items. Like ``(cdr (cdr sequence))``, but more efficient."
+  "Slice of the sequence without the first two items.
+
+  Like ``(cdr (cdr sequence))``, but more efficient.
+  "
   `(operator..getitem ,sequence (slice 2 None)))
 
 (defmacro cascade (thing : :* calls)
@@ -179,15 +187,16 @@ but many macros still require this kind of recursive list processing.
 
 _#"``cond`` is recursive.
 
-Recall that templates are read syntax, which evaluate before macroexpansion.
-Without the forward declaration creating a dummy ``cond`` macro, the reader
-would automatically qualify ``cond`` as ``hissp.basic..cond`` in the template
-instead of ``hissp.basic.._macro_.cond``, because it has no way of knowing it's
+Recall that templates are read syntax, which evaluate before
+macroexpansion. Without the forward declaration creating a dummy
+``cond`` macro, the reader would automatically qualify ``cond`` as
+``hissp.basic..cond`` in the template instead of
+``hissp.basic.._macro_.cond``, because it has no way of knowing it's
 going to be added to the ``_macro_`` namespace later.
 
-We could have used the qualified symbol ``hissp.basic.._macro_.cond`` in the
-template instead of an unqualified ``cond``, then we wouldn't need the forward
-declaration.
+We could have used the qualified symbol ``hissp.basic.._macro_.cond`` in
+the template instead of an unqualified ``cond``, then we wouldn't need
+the forward declaration.
 "
 (defmacro cond ())
 (defmacro cond (: :* pairs)
@@ -278,7 +287,9 @@ declaration.
 (defmacro -> ())
 (defmacro -> (expr : :* forms)
   "``->`` 'Thread-first'.
-  Converts a pipeline to function calls by recursively threading it as the first argument of the next form.
+
+  Converts a pipeline to function calls by recursively threading it as
+  the first argument of the next form.
   E.g. ``(-> x (A b) (C d e))`` is ``(C (A x b) d e)``
   Makes chained method calls easier to read.
   "
@@ -290,7 +301,9 @@ declaration.
 (defmacro ->> ())
 (defmacro ->> (expr : :* forms)
   "``->>`` 'Thread-last'.
-  Converts a pipeline to function calls by recursively threading it as the last argument of the next form.
+
+  Converts a pipeline to function calls by recursively threading it as
+  the last argument of the next form.
   E.g. ``(->> x (A b) (C d e))`` is ``(C d e (A b x))``.
   Can replace partial application in some cases.
   Also works inside a ``->`` pipeline.
@@ -300,13 +313,15 @@ declaration.
     `(->> (,@(car forms) ,expr)
           ,@(cdr forms))
     expr))
+
 ;; TODO: implement other arrange macros?
 
 (defmacro prelude ()
   "Grants unqualified access to the basics.
 
-   Star imports from operator and itertools.
-   And adds the basic macros, if available."
+  Star imports from operator and itertools.
+  And adds the basic macros, if available.
+  "
   `(exec "
 from operator import *
 from itertools import *
@@ -317,7 +332,7 @@ except ModuleNotFoundError:
     pass"))
 
 (defmacro alias (alias module)
-  "Defines a (shorter) reader macro to use in place of a module identifier."
+  "Defines a reader macro abbreviation of a qualifier."
   `(defmacro ,alias ($#G)
      ',(.format "Aliases {} as {}#" module alias)
      (.format "{}{}" ',module $#G)))

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -4,15 +4,13 @@
 Hissp's basic macros.
 
 These are automatically made available as unqualified macros in the
-basic REPL. To use them in a Hissp module, either use the
-fully-qualified names, or add them to the module's ``_macro_``'s.
-
-For example
+basic REPL. To use them in a Hissp module, use the ``prelude`` macro or
+fully-qualified names. You can abbreviate qualifiers with reader macros:
 
 .. code-block:: Lissp
 
-  (hissp.basic.._macro_.from-require
-   (hissp.basic cascade if-else let progn))
+  (hissp.basic.._macro_.alias b/ hissp.basic.._macro_.)
+  (b/#define foo 2)                    ;Same as (hissp.basic.._macro_.define foo 2)
 
 The basic macros are deliberately restricted in design.
 
@@ -247,31 +245,6 @@ declaration.
   `(let ($#value1 ,expr1)
      ,@body
      $#value1))
-
-(defmacro from-require (: :* package+macros)
-  "``from-require``
-  Adds macros for the current module from ``package``
-
-   For example::
-
-    (from-require (foo.package spammacro eggsmacro)
-                  (bar.package baconmacro bannanamacro))
-
-  "
-  `(progn
-     (.setdefault (globals)
-                  ','_macro_
-                  (types..ModuleType '_macro_))
-     ,@(itertools..starmap
-        (lambda (package : :* macros)
-          `(progn ,@(map (lambda (macro)
-                           `(setattr ,'_macro_
-                                     ',macro
-                                     ,(.format "{}.._macro_.{}"
-                                               package
-                                               macro)))
-                         macros)))
-        package+macros)))
 
 (defmacro deftype (name bases : :* body)
   "Defines a type (class) in the current module.

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -60,19 +60,72 @@ and judicious use can improve performance and maintainability.
 ;; Bootstrap macro namespace using builtins.
 (operator..setitem (globals) '_macro_ (types..ModuleType '_macro_))
 
-;; Bootstrap enough of defmacro to defmacro the 'defmacro' macro. Dawg.
+;; Bootstrap enough macros to define the 'defmacro' macro. Dawg.
+
+;; Simplified bootstrap version.
 (setattr _macro_
          'defmacro
          (lambda (name parameters docstring : :* body)
-           `((lambda ($#G (lambda ,parameters ,@body))
+           `((lambda (: $#G (lambda ,parameters ,@body))
                (setattr $#G ','__doc__ ,docstring)
                (setattr $#G ','__qualname__ (.join "." '(,'_macro_ ,name)))
                (setattr _macro_ ',name $#G)))))
+
+(defmacro if-else (test then otherwise)
+  "``if-else``
+  Basic ternary branching construct.
+
+  Like Python's conditional expressions, the else-clause is required.
+  "
+  `((lambda (,'test : :* ,'then-else)
+      ((operator..getitem ,'then-else (operator..not_ ,'test))))
+    ,test
+    (lambda () ,then)
+    (lambda () ,otherwise)))
+
+(defmacro progn (: :* body)
+  "Evaluates each form in sequence for side effects.
+
+  Evaluates to the same value as its last form (or ``()`` if empty).
+  "
+  ;; TODO: consider flattening nested progns
+  `((lambda ()
+      ,@body)))
+
+(defmacro when (condition : :* body)
+  "Evaluates the body when condition is true."
+  `(if-else ,condition (progn ,@body) ()))
+
+(defmacro when-not (condition : :* body)
+  "``when-not`` Evaluates the body when condition is not true."
+  `(when (operator..not_ ,condition) ,@body))
 
 (defmacro let (pairs : :* body)
   "Creates locals. Pairs are implied. Locals are not in scope until the body."
   `((lambda (: ,@pairs)
       ,@body)))
+
+;; Define the real defmacro using the bootstrap macros.
+(defmacro defmacro (name parameters : docstring () :* body)
+  "Creates a new macro for the current module.
+
+  If there's no _macro_, creates one (using ModuleType).
+  If there's a docstring, stores it as the new lambda's __doc__.
+  Adds the _macro_ prefix to the lambda's qualname.
+  Saves the lambda in _macro_ using the given attribute name.
+  "
+  (let ($fn `$#fn)
+    (let (fn `(lambda ,parameters ,docstring ,@body)
+          ns (when-not (operator..contains (.get hissp.compiler..NS) '_macro_)
+               `((operator..setitem (globals) ','_macro_ (types..ModuleType ','_macro_))))
+          dc (when (hissp.reader..is_string docstring)
+               `((setattr ,$fn ','__doc__ ,docstring)))
+          qn `(setattr ,$fn ','__qualname__ (.join "." '(,'_macro_ ,name))))
+      `(let (,$fn ,fn)
+         ,@ns
+         ,@dc
+         ,qn
+         (setattr ,'_macro_ ',name ,$fn)))))
 
 _#"
 Hissp is based on tuples rather than linked lists,
@@ -123,18 +176,6 @@ but many macros still require this kind of recursive list processing.
   `(operator..setitem (builtins..globals)
                       ',name
                       ,value))
-
-(defmacro if-else (test then otherwise)
-  "``if-else``
-  Basic ternary branching construct.
-
-  Like Python's conditional expressions, the else-clause is required.
-  "
-  `((lambda (,'test : :* ,'then-else)
-      ((operator..getitem ,'then-else (operator..not_ ,'test))))
-    ,test
-    (lambda () ,then)
-    (lambda () ,otherwise)))
 
 _#"``cond`` is recursive.
 
@@ -196,15 +237,6 @@ declaration.
                        (|| ,@rest)))
            first))
 
-(defmacro progn (: :* body)
-  "Evaluates each form in sequence for side effects.
-
-  Evaluates to the same value as its last form (or ``()`` if empty).
-  "
-  ;; TODO: consider flattening nested progns
-  `((lambda ()
-      ,@body)))
-
 (defmacro prog1 (expr1 : :* body)
   "Evaluates each expression in sequence (for side effects),
   resulting in the value of the first."
@@ -240,14 +272,6 @@ declaration.
                   `(setattr ,$target ',kw ,(next iargs)))
                 iargs)
          ,$target))))
-
-(defmacro when (condition : :* body)
-  "Evaluates the body when condition is true."
-  `(cond ,condition (progn ,@body)))
-
-(defmacro when-not (condition : :* body)
-  "``when-not`` Evaluates the body when condition is not true."
-  `(when (operator..not_ ,condition) ,@body))
 
 ;; TODO: implement case macro?
 
@@ -297,17 +321,3 @@ except ModuleNotFoundError:
   `(defmacro ,alias ($#G)
      ',(.format "Aliases {} as {}#" module alias)
      (.format "{}{}" ',module $#G)))
-
-(defmacro defmacro (name parameters : docstring () :* body)
-  (let ($G `$#G
-        fn `(lambda ,parameters ,docstring ,@body)
-        ns (when (operator..not_in '_macro_ (.get hissp.compiler.NS))
-             `((operator..setitem (globals) ','_macro_ (types..ModuleType ','_macro_))))
-        dc (when (hissp.reader..is_string docstring)
-             `((setitem ,$G ','__doc__ ,docstring)))
-        qn `(setattr ,$G ','__qualname__ (.join "." '(,'_macro_ ,name))))
-    `(let (,$G ,fn)
-       ,@ns
-       ,@dc
-       ,qn
-       (setattr _macro_ ',name ,$G))))

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -212,12 +212,11 @@ the forward declaration.
          (operator..eq x 0) (print \"zero\")
          :else (print \"not a number\"))
   "
-  (if-else pairs
-           `(if-else ,(car pairs)
-                     ,(cadr pairs)
-                     ;; Here's the recursive part.
-                     (cond ,@(cddr pairs)))
-           ()))
+  (when pairs
+    `(if-else ,(car pairs)
+              ,(cadr pairs)
+              ;; Here's the recursive part.
+              (cond ,@(cddr pairs)))))
 
 (defmacro any-for (item iterable : :* body)
   "``any-for`` Evaluate body for each item in iterable until any result is true."

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -195,7 +195,7 @@ class Compiler:
         case = type(form)
         if case in {int, float, complex}:  # Number literals may need (). E.g. (1).real
             literal = f"({form!r})"
-        elif case in {dict, list, set, tuple}:  # Pretty print collections.
+        elif case in {dict, list, set, tuple, str, bytes}:  # Pretty print collections.
             literal = pformat(form, sort_dicts=False)
         else:
             literal = repr(form)

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -34,7 +34,7 @@ MACRO = f"..{MACROS}."
 # instead of its defining ns.
 # Rather than pass in an implicit argument, it's available here.
 # readerless() uses this automatically.
-NS = ContextVar("NS", default=None)
+NS = ContextVar("NS", default=())
 
 
 class CompileError(SyntaxError):

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -2,45 +2,19 @@
 ;; Copyright 2019, 2020 Matthew Egan Odendahl
 ;; SPDX-License-Identifier: Apache-2.0
 
-(hissp.basic.._macro_.alias B/ hissp.basic.._macro_.)
+(hissp.basic.._macro_.alias ! hissp.basic.._macro_.)
 
-(B/#from-require
- (hissp.basic define
-              deftype
-              defmacro
-              let
-              car
-              cdr
-              caar
-              cdar
-              cadr
-              cddr
-              cascade
-              if-else
-              cond
-              any-for
-              &&
-              ||
-              progn
-              prog1
-              attach
-              when
-              when-not
-              ->
-              ->>
-              _#_))
-
-(define enlist
+(!#define enlist
   (lambda (: :* a) (list a)))
 
-(defmacro tqs ()
+(!#defmacro tqs ()
   `(enlist 'enlist))
 
-(defmacro tqs2 ()
+(!#defmacro tqs2 ()
   "test qualified symbol, with docstring"
   `(enlist 'enlist))
 
-(deftype TestBasic (unittest..TestCase)
+(!#deftype TestBasic (unittest..TestCase)
   test_same_gensym
   (lambda (self)
     (.assertEqual self : :* `($#test $#test)))
@@ -67,8 +41,8 @@
 
   test_let
   (lambda (self)
-    (let (x 1
-          y 2)
+    (!#let (x 1
+            y 2)
       (.assertEqual self x 1)
       (.assertEqual self y 2)))
 
@@ -76,64 +50,70 @@
   (lambda (self)
     (.assertEqual self
                   1
-                  (car [1,2])))
+                  (!#car [1,2])))
 
   test_cdr
   (lambda (self)
     (.assertEqual self
                   [2,3]
-                  (cdr [1,2,3])))
+                  (!#cdr [1,2,3])))
+
+  test_caar
+  (lambda (self)
+    (.assertEqual self
+                  1
+                  (!#caar [[1,2,3]])))
 
   test_cdar
   (lambda (self)
     (.assertEqual self
                   [2,3]
-                  (cdar [[1,2,3]])))
+                  (!#cdar [[1,2,3]])))
 
   test_cadr
   (lambda (self)
     (.assertEqual self
                   2
-                  (cadr [1,2,3])))
+                  (!#cadr [1,2,3])))
 
   test_cddr
   (lambda (self)
     (.assertEqual self
                   [2,3]
-                  (cddr [0,1,2,3])))
+                  (!#cddr [0,1,2,3])))
 
   test_cascade
   (lambda (self)
     (.assertEqual self
-                  (cascade []
+                  (!#cascade []
                            (.append 1)
                            (.extend [2,3]))
                   [1,2,3]))
 
   test_if-else
   (lambda (self)
-    (.assertEqual self (if-else False :yes :no) :no)
-    (.assertEqual self (if-else True :yes :no) :yes)
-    (let (xs [])
-      (if-else False
+    (.assertEqual self (!#if-else False :yes :no) :no)
+    (.assertEqual self (!#if-else True :yes :no) :yes)
+    (!#let (xs [])
+      (!#if-else False
                (.append xs :yes)
                (.append xs :no))
-      (if-else True
+      (!#if-else True
                (.append xs :yes)
                (.append xs :no))
       (.assertEqual self xs [':no',':yes'])))
 
   test_cond
   (lambda (self)
-    (let (xs [])
-      (.append xs (cond))
-      (cond False (.append xs :oops))
-      (cond :else (.append xs 1))
-      (cond False (.append xs :oops)
-            :else (.append xs 2))
-      (cond True (.append xs 3)
-            :else (.append xs :oops))
-      (cond
+    (!#let (xs [])
+      (.append xs (!#cond))
+      (!#cond False (.append xs :oops))
+      (!#cond :else (.append xs 1))
+      (!#cond False (.append xs :oops)
+              :else (.append xs 2))
+      (!#cond True (.append xs 3)
+              :else (.append xs :oops))
+      (!#cond
         False (.append xs :oops)
         0 (.append xs :oops)
         True (.append xs 4)
@@ -142,43 +122,43 @@
 
   test_any-for
   (lambda (self)
-    (let (xs [])
-      (any-for i (range 1 10)
+    (!#let (xs [])
+      (!#any-for i (range 1 10)
         (.append xs i)
         (operator..not_ (operator..mod i 7)))
       (.assertEqual self xs (enlist 1 2 3 4 5 6 7))))
 
   test_&&
   (lambda (self)
-    (let (xs [])
-      (cascade xs
-        (.append (&&))
-        (.append (&& 0))
-        (.append (&& 1))
-        (.append (&& 0 (.append xs :oops)))
-        (.append (&& 1 (.append xs 2)))
-        (.append (&& True
-                     (.append xs 3)
-                     (.append xs :oops)))
-        (.append (&& True
-                     (progn (.append xs 4)
-                            :oops)
-                     (.append xs 5)))
-        (.append (&& 1 2 (progn (.append xs 6) 7))))
+    (!#let (xs [])
+      (!#cascade xs
+        (.append (!#&&))
+        (.append (!#&& 0))
+        (.append (!#&& 1))
+        (.append (!#&& 0 (.append xs :oops)))
+        (.append (!#&& 1 (.append xs 2)))
+        (.append (!#&& True
+                       (.append xs 3)
+                       (.append xs :oops)))
+        (.append (!#&& True
+                       (!#progn (.append xs 4)
+                                :oops)
+                       (.append xs 5)))
+        (.append (!#&& 1 2 (!#progn (.append xs 6) 7))))
       (.assertEqual self
                     [True,0,1,0,2,None,3,None,4,5,None,6,7]
                     xs)))
 
   test_||
   (lambda (self)
-    (let (xs [])
-      (cascade xs
-        (.append (||))
-        (.append (|| 0))
-        (.append (|| 1))
-        (.append (|| 2 (.append xs :oops)))
-        (.append (|| 0 (.append xs 3)))
-        (.append (|| 0 (.append xs 5) 6)))
+    (!#let (xs [])
+      (!#cascade xs
+        (.append (!#||))
+        (.append (!#|| 0))
+        (.append (!#|| 1))
+        (.append (!#|| 2 (.append xs :oops)))
+        (.append (!#|| 0 (.append xs 3)))
+        (.append (!#|| 0 (.append xs 5) 6)))
       (.assertEqual self
                     (enlist () 0 1 2 3 None 5 6)
                     xs)))
@@ -186,8 +166,8 @@
   test_progn
   (lambda (self)
     (.assertEqual self
-                  (let (xs [])
-                    (progn
+                  (!#let (xs [])
+                    (!#progn
                       (.append xs 1)
                       (.extend xs "bc")
                       xs))
@@ -195,41 +175,41 @@
 
   test_prog1
   (lambda (self)
-    (let (xs [])
-      (.append xs (prog1 3
+    (!#let (xs [])
+      (.append xs (!#prog1 3
                     (.append xs 1)
                     (.append xs 2)))
       (.assertEqual self [1,2,3] xs)))
 
   test_attach
   (lambda (self)
-    (let (ns (types..SimpleNamespace)
-          x 1
-          y 2
-          z 3)
-      (attach ns x y z : p 4  q 5  r 6)
+    (!#let (ns (types..SimpleNamespace)
+            x 1
+            y 2
+            z 3)
+      (!#attach ns x y z : p 4  q 5  r 6)
       (.assertEqual self
                     (types..SimpleNamespace : x 1  y 2  z 3  p 4  q 5  r 6)
                     ns)))
 
   test_when
   (lambda (self)
-    (let (xs [])
-      (when 1
+    (!#let (xs [])
+      (!#when 1
         (.append xs 1)
         (.append xs 2))
-      (when 0
+      (!#when 0
         (.append xs :oops)
         (.append xs :oops))
       (.assertEqual self [1,2] xs)))
 
   test_when-not
   (lambda (self)
-    (let (xs [])
-      (when-not 0
+    (!#let (xs [])
+      (!#when-not 0
         (.append xs 1)
         (.append xs 2))
-      (when-not 1
+      (!#when-not 1
         (.append xs :oops)
         (.append xs :oops))
       (.assertEqual self [1,2] xs)))
@@ -237,29 +217,29 @@
   test_->
   (lambda (self)
     (.assertEqual self
-                  (-> "-x-" (.replace "x" "y") (.strip "-") (.upper))
+                  (!#-> "-x-" (.replace "x" "y") (.strip "-") (.upper))
                   "Y"))
 
   test_->>
   (lambda (self)
     (.assertEqual self
-                  (->> (range 3)
-                       (map (lambda (x) (operator..mul x x)))
-                       (filter (lambda (x) ; even?
-                                 (operator..eq 0 (operator..mod x 2))))
-                       (list))
+                  (!#->> (range 3)
+                         (map (lambda (x) (operator..mul x x)))
+                         (filter (lambda (x) ; even?
+                                   (operator..eq 0 (operator..mod x 2))))
+                         (list))
                   [0,4]))
 
   test_prelude
   (lambda (self)
-    (let (ns {})
+    (!#let (ns {})
       (exec (hissp.compiler..readerless '(hissp.basic.._macro_.prelude)) ns)
       (.assertEqual self
                     (set operator..__all__)
                     (.intersection (set operator..__all__) (.keys ns)))
       ;; Asserts everything public in itertools is in ns.
-      (let (members (set (itertools..filterfalse (lambda x (.startswith x "_"))
-                                                 (dir itertools.))))
+      (!#let (members (set (itertools..filterfalse (lambda x (.startswith x "_"))
+                                                   (dir itertools.))))
         (.assertEqual self
                       members
                       (.intersection members (.keys ns))))

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -203,13 +203,13 @@
         (.append xs :oops))
       (.assertEqual self [1,2] xs)))
 
-  test_when-not
+  test_unless
   (lambda (self)
     (!#let (xs [])
-      (!#when-not 0
+      (!#unless 0
         (.append xs 1)
         (.append xs 2))
-      (!#when-not 1
+      (!#unless 1
         (.append xs :oops)
         (.append xs :oops))
       (.assertEqual self [1,2] xs)))


### PR DESCRIPTION
Improvements to the readability of the compiled code. Defmacro expansions are cleaner, and the implementation is a bit easier to understand. Closes #69. Long strings are pretty-printed. You can actually read the module docstrings in the compiled output now.