### PR TITLE
No forward declarations

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1013,17 +1013,19 @@ This behavior is very much like a Lisp-2.
 
 This allows you do do things like write a macro that inlines a small function,
 while still being able to pass a function object to higher-order functions
-like `map` using the same name.
+(like `map`) using the same unqualified name.
 This behavior is similar to Hy, which uses this ability for its operators,
 but is completely unlike Clojure.
 
 And it does have a cost:
-Unlike Clojure,
-you have to declare a forward reference for recursive macros,
-or the template quote will qualify them as a variable.
-
-.. TODO: When qualifying invocation position, always qualify as a macro,
-    and when compiling, if it's absent, fall back to the global.
+Unlike Clojure's syntax quote,
+there are cases when the way Lissp's template quote should qualify a symbol is ambiguous.
+When neither a function nor a macro has yet been declared for an identifier,
+which way should it be qualified?
+What if both have?
+Try it.
+These template-quote qualification rules mostly just work,
+but you may run into edge cases in Lissp that couldn't exist in Clojure.
 
 If you wanted semantics more like a Lisp-2,
 Lissp can do it pretty easily.

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -107,8 +107,8 @@ But it's not technically wrong.
 .. code-block:: Lissp
 
    #> `op.add
-   >>> '__main__..op.add'
-   '__main__..op.add'
+   >>> '__main__...op.add'
+   '__main__...op.add'
 
 And you can still qualify it yourself instead of letting the reader do it for you:
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -107,8 +107,8 @@ But it's not technically wrong.
 .. code-block:: Lissp
 
    #> `op.add
-   >>> '__main__...op.add'
-   '__main__...op.add'
+   >>> '__main__..op.add'
+   '__main__..op.add'
 
 And you can still qualify it yourself instead of letting the reader do it for you:
 

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -502,7 +502,7 @@ Lissp Quick Start
 
    ;;; linked-list emulation
 
-   ;; These really could be functions, but their expansion is small enough to inline.
+   ;; These really could be functions, but their expansions are small enough to inline.
 
    (car "abcd")                           ;'a'
    (cdr "abcd")                           ;'bcd'

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -388,20 +388,7 @@ Lissp Quick Start
                  (,@body))))
    (list (map (fnx mul X X) (range 6)))   ;Shorter lambda! Don't nest them.
 
-   ;; Recursive macro? (Multiary +)
-   (setattr _macro_
-            '+
-             (lambda (first : :* args)
-               (.__getitem__
-                 `(,first ,`(add ,first (+ ,@args)))
-                 (bool args))))
-   (+ 1 2 3 4)                            ;TypeError
-
-   _#"The recursive + was qualified as __main__..+, not __main__.._macro_.xPLUS_.
-   Recursive macro invocations require forward declaration or explicit qualification.
-   Now that we have a _macro_.+, it will qualify properly when you run it again."
-
-   ;; Same as before.
+   ;; Recursive macro. (Multiary +)
    (setattr _macro_
             '+
              (lambda (first : :* args)
@@ -410,7 +397,6 @@ Lissp Quick Start
                  (bool args))))
    (+ 1 2 3 4)                            ;10
 
-   (setattr _macro_ '* None)              ;Forward declaration.
    (setattr _macro_
             '*
              (lambda (first : :* args)

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1094,15 +1094,15 @@ We can do better. Let's use a template:
     ...       'builtins..print',
     ...       (lambda *xAUTO0_:xAUTO0_)(
     ...         'quote',
-    ...         '__main__...Hello'),
+    ...         '__main__..Hello'),
     ...       name)))
 
     #> (greet 'Bob)
     >>> # greet
     ... __import__('builtins').print(
-    ...   '__main__...Hello',
+    ...   '__main__..Hello',
     ...   'Bob')
-    __main__...Hello Bob
+    __main__..Hello Bob
 
 Not what you expected?
 
@@ -1119,8 +1119,8 @@ with `builtins` (if applicable) or the current ``__name__``
     #> `(int spam)
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..int',
-    ...   '__main__...spam')
-    ('builtins..int', '__main__...spam')
+    ...   '__main__..spam')
+    ('builtins..int', '__main__..spam')
 
 Qualified symbols are especially important
 when a macro expands in a module it was not defined in.
@@ -1147,8 +1147,8 @@ symbol. (Like a quoted symbol):
     #> `(float inf)
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..float',
-    ...   '__main__...inf')
-    ('builtins..float', '__main__...inf')
+    ...   '__main__..inf')
+    ('builtins..float', '__main__..inf')
 
     #> `(float ,'inf)
     >>> (lambda *xAUTO0_:xAUTO0_)(

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1094,15 +1094,15 @@ We can do better. Let's use a template:
     ...       'builtins..print',
     ...       (lambda *xAUTO0_:xAUTO0_)(
     ...         'quote',
-    ...         '__main__..Hello'),
+    ...         '__main__...Hello'),
     ...       name)))
 
     #> (greet 'Bob)
     >>> # greet
     ... __import__('builtins').print(
-    ...   '__main__..Hello',
+    ...   '__main__...Hello',
     ...   'Bob')
-    __main__..Hello Bob
+    __main__...Hello Bob
 
 Not what you expected?
 
@@ -1119,8 +1119,8 @@ with `builtins` (if applicable) or the current ``__name__``
     #> `(int spam)
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..int',
-    ...   '__main__..spam')
-    ('builtins..int', '__main__..spam')
+    ...   '__main__...spam')
+    ('builtins..int', '__main__...spam')
 
 Qualified symbols are especially important
 when a macro expands in a module it was not defined in.
@@ -1147,8 +1147,8 @@ symbol. (Like a quoted symbol):
     #> `(float inf)
     >>> (lambda *xAUTO0_:xAUTO0_)(
     ...   'builtins..float',
-    ...   '__main__..inf')
-    ('builtins..float', '__main__..inf')
+    ...   '__main__...inf')
+    ('builtins..float', '__main__...inf')
 
     #> `(float ,'inf)
     >>> (lambda *xAUTO0_:xAUTO0_)(

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -228,7 +228,6 @@ but many macros still require this kind of recursive list processing.
 
 ;;; threading
 
-(defmacro -> ())
 (defmacro -> (expr : :* forms)
   "``->`` 'Thread-first'.
 
@@ -242,7 +241,6 @@ but many macros still require this kind of recursive list processing.
          ,@(cdr forms))
     expr))
 
-(defmacro ->> ())
 (defmacro ->> (expr : :* forms)
   "``->>`` 'Thread-last'.
 
@@ -262,20 +260,6 @@ but many macros still require this kind of recursive list processing.
 
 ;;; control flow
 
-_#"``cond`` is recursive.
-
-Recall that templates are read syntax, which evaluate before
-macroexpansion. Without the forward declaration creating a dummy
-``cond`` macro, the reader would automatically qualify ``cond`` as
-``hissp.basic..cond`` in the template instead of
-``hissp.basic.._macro_.cond``, because it has no way of knowing it's
-going to be added to the ``_macro_`` namespace later.
-
-We could have used the qualified symbol ``hissp.basic.._macro_.cond`` in
-the template instead of an unqualified ``cond``, then we wouldn't need
-the forward declaration.
-"
-(defmacro cond ())
 (defmacro cond (: :* pairs)
   "Multiple condition branching.
 
@@ -302,7 +286,6 @@ the forward declaration.
              ,iterable)))
 
 ;; I would have named this 'and, but that's a reserved word.
-(defmacro && ())  ; Forward declaration because && is recursive.
 (defmacro && (: :* exprs)
   "``&&`` 'and'. Like Python's ``and`` operator, but for any number of arguments."
   (cond (operator..not_ exprs) True
@@ -312,7 +295,6 @@ the forward declaration.
                           (&& ,@(cdr exprs))
                           $#G))))
 
-(defmacro || ())  ; Forward declaration because || is recursive.
 (defmacro || (: first () :* rest)
   "``||`` 'or'. Like Python's ``or`` operator, but for any number of arguments."
   (if-else rest

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -29,7 +29,7 @@ PAIR_WORDS = {":*": "*", ":**": "**", ":?": ""}
 MACROS = "_macro_"
 # Macro from foreign module foo.bar.._macro_.baz
 MACRO = f"..{MACROS}."
-RE_MACRO = re.compile(rf"(\.\.{MACROS}\.|\.\.\.)")
+RE_MACRO = re.compile(rf"(\.\.{MACROS}\.|\.\.xAUTO_\.)")
 
 # Sometimes macros need the current ns when expanding,
 # instead of its defining ns.
@@ -145,6 +145,7 @@ class Compiler:
         """Try to compile as macro, else normal call."""
         if result := self.macro(form):
             return f"# {form[0]}\n{result}"
+        form = form[0].replace("..xAUTO_.", "..", 1), *form[1:]
         return self.call(form)
 
     @_trace
@@ -156,7 +157,7 @@ class Compiler:
 
     def _get_macro(self, head):
         parts = RE_MACRO.split(head, 1)
-        head = head.replace("...", MACRO, 1)
+        head = head.replace("..xAUTO_.", MACRO, 1)
         if len(parts) > 1:
             macro = self._qualified_macro(head, parts)
         else:
@@ -170,7 +171,7 @@ class Compiler:
             else:
                 return eval(self.symbol(head))
         except (KeyError, AttributeError):
-            if parts[1] != "...":
+            if parts[1] != "..xAUTO_.":
                 raise
 
     def _unqualified_macro(self, head):

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -29,6 +29,7 @@ PAIR_WORDS = {":*": "*", ":**": "**", ":?": ""}
 MACROS = "_macro_"
 # Macro from foreign module foo.bar.._macro_.baz
 MACRO = f"..{MACROS}."
+RE_MACRO = re.compile(rf"(\.\.{MACROS}\.|\.\.\.)")
 
 # Sometimes macros need the current ns when expanding,
 # instead of its defining ns.
@@ -149,22 +150,34 @@ class Compiler:
     @_trace
     def macro(self, form: Tuple) -> Optional[str]:
         head, *tail = form
-        parts = head.split(MACRO, 1)
-        with self.macro_context():
-            if parts[0] == self.qualname:
-                # Local qualified macro. Recursive macros might need it.
-                result = self.form(vars(self.ns[MACROS])[parts[1]](*tail))
+        if (macro := self._get_macro(head)) is not None:
+            with self.macro_context():
+                return self.form(macro(*tail))
+
+    def _get_macro(self, head):
+        parts = RE_MACRO.split(head, 1)
+        head = head.replace("...", MACRO, 1)
+        if len(parts) > 1:
+            macro = self._qualified_macro(head, parts)
+        else:
+            macro = self._unqualified_macro(head)
+        return macro
+
+    def _qualified_macro(self, head, parts):
+        try:
+            if parts[0] == self.qualname:  # Internal?
+                return vars(self.ns[MACROS])[parts[2]]
             else:
-                try:  # Is it a local unqualified macro?
-                    macro = vars(self.ns[MACROS])[head]
-                except LookupError:  # Nope.
-                    if MACRO in head:  # Qualified macro, not local.
-                        result = self.form(eval(self.symbol(head))(*tail))
-                    else:
-                        result = None
-                else:  # Local unqualified.
-                    result = self.form(macro(*tail))
-        return result
+                return eval(self.symbol(head))
+        except (KeyError, AttributeError):
+            if parts[1] != "...":
+                raise
+
+    def _unqualified_macro(self, head):
+        try:
+            return vars(self.ns[MACROS])[head]
+        except KeyError:
+            pass
 
     @_trace
     def quoted(self, form) -> str:

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -19,6 +19,8 @@ from unittest.mock import ANY
 from hissp.compiler import Compiler, readerless
 from hissp.munger import munge
 
+ENTUPLE = ("lambda", (":", ":*", "xAUTO0_"), "xAUTO0_")
+
 TOKENS = re.compile(
     r"""(?x)
  (?P<open>\()
@@ -230,7 +232,7 @@ class Lissp:
             if is_string(form):
                 return "quote", form
             return (
-                ("lambda", (":", ":*", "xAUTO0_"), "xAUTO0_"),
+                ENTUPLE,
                 ":",
                 *chain(*self._template(form)),
             )
@@ -259,7 +261,9 @@ class Lissp:
             return f"{self.qualname}.._macro_.{symbol}"
         if symbol in dir(builtins) and symbol not in self.ns:
             return f"builtins..{symbol}"  # Globals shadow builtins.
-        return f"{self.qualname}..{symbol}"
+        if symbol in self.ns:
+            return f"{self.qualname}..{symbol}"
+        return f"{self.qualname}...{symbol}"  # Name wasn't found. Decide at compile time.
 
     def reads(self, code: str) -> Iterable:
         res: Iterable[object] = self.parse(Lexer(code, self.filename))

--- a/tests/test_munger.py
+++ b/tests/test_munger.py
@@ -15,7 +15,7 @@ class TestMunger(TestCase):
     def test_demunge(self, s: str):
         x = munger.munge(s)
         self.assertEqual(x, munger.munge(munger.demunge(x)))
-        if "x" not in s:
+        if not s.startswith(":") and "x" not in s:
             self.assertEqual(unicodedata.normalize("NFKC", s), munger.demunge(x))
 
     def test_munge_basic(self):


### PR DESCRIPTION
Rework template qualification so `defmacro` no longer requires forward declarations or explicit qualification for recursive macros.

Closes #64.

This is another special case in the compiler. It's a little more magical than before. I'm really trying to keep the compiler simple, but qualified identifiers are such a core feature of Hissp (and Lissp) that I think this is worth it. As simple as possible, but no simpler.