### PR TITLE
Update (-):ssp logo for compatibility with GitHub dark mode

### DIFF
--- a/docs/hissp.svg
+++ b/docs/hissp.svg
@@ -1,102 +1,48 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg
-        xmlns:dc="http://purl.org/dc/elements/1.1/"
-        xmlns:cc="http://creativecommons.org/ns#"
-        xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-        xmlns="http://www.w3.org/2000/svg"
-        xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-        xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-        width="144.95607mm"
-        height="57.494839mm"
-        viewBox="0 0 144.95607 57.494839"
-        version="1.1"
-        id="svg8"
-        sodipodi:docname="hissp.svg"
-        inkscape:version="1.0.1 (3bc2e813f5, 2020-09-07)">
-  <defs
-     id="defs2" />
-  <sodipodi:namedview
-     id="base"
-     pagecolor="#ffffff"
-     bordercolor="#666666"
-     borderopacity="1.0"
-     inkscape:pageopacity="0.0"
-     inkscape:pageshadow="2"
-     inkscape:zoom="0.70710678"
-     inkscape:cx="258.53373"
-     inkscape:cy="315.70781"
-     inkscape:document-units="mm"
-     inkscape:current-layer="text12"
-     inkscape:document-rotation="0"
-     showgrid="false"
-     inkscape:window-width="1765"
-     inkscape:window-height="1005"
-     inkscape:window-x="139"
-     inkscape:window-y="0"
-     inkscape:window-maximized="0"
-     inkscape:snap-nodes="true"
-     inkscape:snap-bbox="true"
-     inkscape:bbox-paths="true"
-     inkscape:snap-midpoints="true" />
-  <metadata
-     id="metadata5">
-    <rdf:RDF>
-      <cc:Work
-         rdf:about="">
-        <dc:format>image/svg+xml</dc:format>
-        <dc:type
-           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
-      </cc:Work>
-    </rdf:RDF>
-  </metadata>
-  <g
-     inkscape:label="Layer 1"
-     inkscape:groupmode="layer"
-     id="layer1">
-    <g
-       aria-label="((–):ssp)"
-       id="text12"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;line-height:1.25;font-family:'Myanmar Text';-inkscape-font-specification:'Myanmar Text Bold';stroke-width:0.264583">
-      <path
-         id="path858-9"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;line-height:1.25;font-family:'Myanmar Text';-inkscape-font-specification:'Myanmar Text Bold';fill:#ffd43c;fill-opacity:1;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="m 42.208044,0.685 c 5.341276,7.9856366 8.011914,17.187835 8.011914,27.606594 0,10.793091 -2.670638,19.891306 -8.011914,27.294656 h -1.938383 -4.461226 c 3.515775,-8.152007 5.27358,-17.250222 5.27358,-27.294656 0,-10.044433 -1.746235,-19.246631 -5.238957,-27.606594 h 0.01499 4.411617 z" />
-      <path
-         id="path858"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'Myanmar Text';-inkscape-font-specification:'Myanmar Text Bold';fill:#3a75a5;fill-opacity:1;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         d="M 8.696914,0.685 C 3.355638,8.6706364 0.685,17.872835 0.685,28.291594 c 0,10.79309 2.670638,19.891305 8.011914,27.294656 h 1.938383 4.461226 C 11.580748,47.434242 9.822944,38.336027 9.822944,28.291594 9.822944,18.247161 11.569178,9.0449627 15.0619,0.685 c -1.475536,0 -2.951071,0 -4.426607,0 z"
-         sodipodi:nodetypes="cscccsccc" />
-      <g
-         aria-label="-:ssp"
-         id="text1330-5"
-         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;line-height:1.25;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-         transform="translate(3.5954167,0.685)">
-        <path
-           d="m 13.303583,23.6307 h 17.140039 q 0.942578,0 1.5875,0.620117 0.843359,0.84336 0.843359,2.331641 0,1.909961 -1.289843,2.654102 -0.520899,0.297656 -1.141016,0.297656 H 13.303583 q -0.967383,0 -1.612304,-0.644922 -0.868164,-0.843359 -0.868164,-2.331641 0,-1.984375 1.389062,-2.678906 0.471289,-0.248047 1.091406,-0.248047 z"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#3fa73f;fill-opacity:1;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path1350" />
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.49984;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 45.69833,34.713286 q 1.00272,0 1.932072,0.542738 2.616856,1.537758 2.616856,5.095709 0,1.356845 -0.538045,2.623235 -1.271744,2.98506 -4.059796,2.98506 -1.491853,0 -2.690226,-1.115628 -1.834245,-1.718671 -1.834245,-4.552971 0,-2.351866 1.394026,-4.010232 1.345113,-1.567911 3.179358,-1.567911 z"
-           id="path1445" />
-        <path
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.49984;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           d="m 45.69833,16.829106 q 1.00272,0 1.932072,0.542739 2.616856,1.567911 2.616856,5.095709 0,1.356845 -0.538045,2.623235 -1.271744,2.98506 -4.059796,2.98506 -1.491853,0 -2.690226,-1.115629 -1.834245,-1.718671 -1.834245,-4.55297 0,-2.351866 1.394026,-4.010233 1.345113,-1.567911 3.179358,-1.567911 z"
-           id="path1352" />
-        <path
-           d="m 68.791668,17.379919 q 5.382617,0 8.632031,2.257227 1.761132,1.215429 1.761132,2.877343 0,0.967383 -0.595312,1.810742 -0.818555,1.116211 -2.232422,1.116211 -0.917773,0 -2.033984,-0.868164 -2.530078,-1.95957 -5.630664,-1.95957 -4.01836,0 -4.01836,2.282031 0,1.339453 1.438672,2.083594 0.471289,0.223242 1.612305,0.595312 6.72207,2.05879 8.30957,2.85254 4.142383,2.058789 4.142383,6.573242 0,4.191992 -3.323828,6.424414 -2.902149,1.934765 -7.863086,1.934765 -5.680273,0 -9.351367,-2.579687 -2.38125,-1.686719 -2.38125,-3.522266 0,-0.868164 0.570508,-1.686719 0.79375,-1.116211 2.108398,-1.116211 1.041797,0 1.959571,0.868165 2.778124,2.654101 7.044531,2.654101 4.440039,0 4.440039,-2.38125 0,-1.612305 -2.232422,-2.703711 -1.438672,-0.669726 -6.920508,-2.356445 -5.953125,-1.810742 -5.953125,-7.267773 0,-4.266407 4.092774,-6.474024 2.604492,-1.413867 6.424414,-1.413867 z"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path1354" />
-        <path
-           d="m 96.22565,17.379919 q 5.38262,0 8.63203,2.257227 1.76113,1.215429 1.76113,2.877343 0,0.967383 -0.59531,1.810742 -0.81855,1.116211 -2.23242,1.116211 -0.91777,0 -2.03398,-0.868164 -2.530082,-1.95957 -5.630668,-1.95957 -4.01836,0 -4.01836,2.282031 0,1.339453 1.438672,2.083594 0.471289,0.223242 1.612305,0.595312 6.722071,2.05879 8.309571,2.85254 4.14238,2.058789 4.14238,6.573242 0,4.191992 -3.32383,6.424414 -2.90214,1.934765 -7.863082,1.934765 -5.680273,0 -9.351367,-2.579687 -2.38125,-1.686719 -2.38125,-3.522266 0,-0.868164 0.570508,-1.686719 0.79375,-1.116211 2.108398,-1.116211 1.041797,0 1.95957,0.868165 2.778125,2.654101 7.044532,2.654101 4.440041,0 4.440041,-2.38125 0,-1.612305 -2.232424,-2.703711 -1.438672,-0.669726 -6.920508,-2.356445 -5.953125,-1.810742 -5.953125,-7.267773 0,-4.266407 4.092773,-6.474024 2.604493,-1.413867 6.424414,-1.413867 z"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path1356" />
-        <path
-           d="m 120.55905,41.911755 v 11.48457 q 0,0.967383 -0.59531,1.661914 -0.91777,1.066601 -2.62929,1.066601 -1.90997,0 -2.77813,-1.339453 -0.39687,-0.595312 -0.39687,-1.389062 V 20.430896 q 0,-1.116211 0.5457,-1.785938 0.71933,-0.917773 2.1332,-0.917773 2.25723,0 2.70371,2.38125 l 0.39688,2.133203 q 0.96738,-1.885156 2.70371,-3.050977 2.50527,-1.661914 5.8539,-1.661914 6.3252,0 9.74825,5.109766 2.43086,3.621484 2.43086,8.805664 0,5.060156 -2.6293,8.756054 -3.59668,5.060156 -9.77305,5.060156 -5.08496,0 -7.71426,-3.348632 z m -0.0496,-10.914063 v 1.959571 q 0,2.827734 2.05878,4.886523 2.00918,2.033984 4.7129,2.033984 3.175,0 5.08496,-2.654101 1.66191,-2.306836 1.66191,-5.754688 0,-3.497461 -1.5627,-5.779492 -1.88515,-2.728515 -5.13457,-2.728515 -2.77812,0 -4.8121,2.430859 -2.00918,2.406055 -2.00918,5.605859 z"
-           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:50.8px;font-family:'UD Digi Kyokasho NK-B';-inkscape-font-specification:'UD Digi Kyokasho NK-B Bold';fill:#cccccc;stroke:#ffffff;stroke-width:1.37;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
-           id="path1358" />
-      </g>
-    </g>
+<svg width="144.96mm" height="57.495mm" enable-background="new" version="1.1" viewBox="0 0 144.96 57.495" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+ <defs>
+  <linearGradient id="a">
+   <stop stop-color="#fff" offset="0"/>
+   <stop offset="1"/>
+  </linearGradient>
+  <linearGradient id="e" x1="44.72" x2="50.668" y1="41.022" y2="41.022" gradientUnits="userSpaceOnUse" spreadMethod="reflect">
+   <stop offset="0"/>
+   <stop stop-color="#fff" offset="1"/>
+  </linearGradient>
+  <radialGradient id="c" cx="50.697" cy="21.233" r="4.5612" gradientTransform="matrix(1.5509 0 0 2.4513 -28.023 -31.026)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+  <filter id="i" color-interpolation-filters="sRGB">
+   <feBlend in2="BackgroundImage" mode="overlay"/>
+  </filter>
+  <linearGradient id="h" x1=".685" x2="15.097" y1="28.136" y2="28.136" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#1b3775" offset="0"/>
+   <stop stop-color="#55add0" offset="1"/>
+  </linearGradient>
+  <linearGradient id="g" x1="14.419" x2="36.47" y1="27.267" y2="27.267" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#1d771d" offset="0"/>
+   <stop stop-color="#63da63" offset="1"/>
+  </linearGradient>
+  <linearGradient id="f" x1="135.34" x2="189.72" y1="106.34" y2="106.34" gradientUnits="userSpaceOnUse">
+   <stop stop-color="#ffbf1d" offset="0"/>
+   <stop stop-color="#ffec5d" offset="1"/>
+  </linearGradient>
+  <radialGradient id="b" cx="50.272" cy="21.85" r="4.5612" gradientTransform="matrix(3.3493 -2.6744e-7 2.6288e-7 3.2921 -118.1 -50.383)" gradientUnits="userSpaceOnUse" xlink:href="#a"/>
+  <linearGradient id="d" x1="50.146" x2="63.571" y1="41.022" y2="41.022" gradientUnits="userSpaceOnUse" xlink:href="#a" spreadMethod="reflect"/>
+ </defs>
+ <g>
+  <g>
+   <path d="m8.6969 0.685c-5.3413 7.9856-8.0119 17.188-8.0119 27.607 0 10.793 2.6706 19.891 8.0119 27.295h6.3996c-3.5158-8.152-5.2736-17.25-5.2736-27.295s1.7462-19.247 5.239-27.607h-4.4266z" fill="url(#h)"/>
+   <path d="m16.899 24.316h17.14q0.94258 0 1.5875 0.62012 0.84336 0.84336 0.84336 2.3316 0 1.91-1.2898 2.6541-0.5209 0.29766-1.141 0.29766h-17.14q-0.96738 0-1.6123-0.64492-0.86816-0.84336-0.86816-2.3316 0-1.9844 1.3891-2.6789 0.47129-0.24805 1.0914-0.24805z" fill="url(#g)"/>
+   <path d="m49.294 17.514c-1.2228 0-2.2824 0.52259-3.1791 1.5679-0.92935 1.1056-1.3942 2.4422-1.3942 4.0101 0 1.8895 0.61168 3.4074 1.8345 4.5532 0.79892 0.74375 1.6957 1.1157 2.6903 1.1157 1.8587 0 3.2119-0.99531 4.0597-2.9853 0.3587-0.84426 0.53795-1.7185 0.53795-2.6231 0-2.3519-0.87232-4.0505-2.6169-5.0958-0.61957-0.36183-1.2637-0.5426-1.9322-0.5426z" fill="url(#b)"/>
+   <path d="m49.294 35.398c-1.2228 0-2.2824 0.52259-3.1791 1.5679-0.92935 1.1056-1.3942 2.4422-1.3942 4.0101 0 1.8895 0.61168 3.4074 1.8345 4.5532 0.79892 0.74375 1.6957 1.1157 2.6903 1.1157 1.8587 0 3.2119-0.99531 4.0597-2.9854 0.3587-0.84426 0.53795-1.7185 0.53795-2.6231 0-2.372-0.87232-4.0706-2.6169-5.0958-0.61957-0.36182-1.2637-0.5426-1.9322-0.5426z" fill="url(#d)"/>
   </g>
+  <g fill="#ccc">
+   <path d="m72.387 18.065q5.3826 0 8.632 2.2572 1.7611 1.2154 1.7611 2.8773 0 0.96738-0.59531 1.8107-0.81856 1.1162-2.2324 1.1162-0.91777 0-2.034-0.86816-2.5301-1.9596-5.6307-1.9596-4.0184 0-4.0184 2.282 0 1.3395 1.4387 2.0836 0.47129 0.22324 1.6123 0.59531 6.7221 2.0588 8.3096 2.8525 4.1424 2.0588 4.1424 6.5732 0 4.192-3.3238 6.4244-2.9021 1.9348-7.8631 1.9348-5.6803 0-9.3514-2.5797-2.3812-1.6867-2.3812-3.5223 0-0.86816 0.57051-1.6867 0.79375-1.1162 2.1084-1.1162 1.0418 0 1.9596 0.86816 2.7781 2.6541 7.0445 2.6541 4.44 0 4.44-2.3812 0-1.6123-2.2324-2.7037-1.4387-0.66973-6.9205-2.3564-5.9531-1.8107-5.9531-7.2678 0-4.2664 4.0928-6.474 2.6045-1.4139 6.4244-1.4139z"/>
+   <path d="m99.821 18.065q5.3826 0 8.632 2.2572 1.7611 1.2154 1.7611 2.8773 0 0.96738-0.59531 1.8107-0.81855 1.1162-2.2324 1.1162-0.91777 0-2.034-0.86816-2.5301-1.9596-5.6307-1.9596-4.0184 0-4.0184 2.282 0 1.3395 1.4387 2.0836 0.47129 0.22324 1.6123 0.59531 6.7221 2.0588 8.3096 2.8525 4.1424 2.0588 4.1424 6.5732 0 4.192-3.3238 6.4244-2.9021 1.9348-7.8631 1.9348-5.6803 0-9.3514-2.5797-2.3812-1.6867-2.3812-3.5223 0-0.86816 0.57051-1.6867 0.79375-1.1162 2.1084-1.1162 1.0418 0 1.9596 0.86816 2.7781 2.6541 7.0445 2.6541 4.44 0 4.44-2.3812 0-1.6123-2.2324-2.7037-1.4387-0.66973-6.9205-2.3564-5.9531-1.8107-5.9531-7.2678 0-4.2664 4.0928-6.474 2.6045-1.4139 6.4244-1.4139z"/>
+   <path d="m124.15 42.597v11.485q0 0.96738-0.59531 1.6619-0.91777 1.0666-2.6293 1.0666-1.91 0-2.7781-1.3395-0.39687-0.59531-0.39687-1.3891v-32.965q0-1.1162 0.5457-1.7859 0.71933-0.91777 2.1332-0.91777 2.2572 0 2.7037 2.3812l0.39688 2.1332q0.96738-1.8852 2.7037-3.051 2.5053-1.6619 5.8539-1.6619 6.3252 0 9.7482 5.1098 2.4309 3.6215 2.4309 8.8057 0 5.0602-2.6293 8.7561-3.5967 5.0602-9.773 5.0602-5.085 0-7.7143-3.3486zm-0.0496-10.914v1.9596q0 2.8277 2.0588 4.8865 2.0092 2.034 4.7129 2.034 3.175 0 5.085-2.6541 1.6619-2.3068 1.6619-5.7547 0-3.4975-1.5627-5.7795-1.8852-2.7285-5.1346-2.7285-2.7781 0-4.8121 2.4309-2.0092 2.4061-2.0092 5.6059z"/>
+  </g>
+  <path transform="scale(.26458)" d="m135.47 2.5898c13.201 31.597 19.801 66.377 19.801 104.34 0 37.963-6.6437 72.349-19.932 103.16h24.188c7.0197-9.7298 12.816-20.237 17.395-31.516-1.4884-0.82608-2.8983-1.8348-4.1856-3.0332l-8e-3 -6e-3 -8e-3 -8e-3c-5.5673-5.2165-8.4219-12.493-8.4219-20.654 0-6.8598 2.157-13.177 6.377-18.197l0.0156-0.0215 0.0156-0.0156c4.08-4.7558 9.6299-7.5742 15.598-7.5742 0.81565 0 1.6282 0.0592 2.4336 0.16797 0.5192-5.2572 0.84383-10.639 0.98438-16.137-1.1696 0.21336-2.3708 0.33399-3.6035 0.33399-4.9369 0-9.6477-2.0072-13.383-5.4844l-8e-3 -8e-3 -8e-3 -6e-3c-5.5673-5.2165-8.4219-12.495-8.4219-20.656 0-6.8598 2.157-13.175 6.377-18.195l0.0156-0.01563 0.0156-0.02148c3.7536-4.3753 8.7512-7.104 14.174-7.5137-4.8573-21.283-13.307-40.929-25.353-58.939h-24z" fill="url(#f)"/>
+ </g>
+ <g display="none" filter="url(#i)" opacity=".6">
+  <path d="m49.294 17.514c-1.2228 0-2.2824 0.52259-3.1791 1.5679-0.92935 1.1056-1.3942 2.4422-1.3942 4.0101 0 1.8895 0.61168 3.4074 1.8345 4.5532 0.79892 0.74375 1.6957 1.1157 2.6903 1.1157 1.8587 0 3.2119-0.99531 4.0597-2.9853 0.3587-0.84426 0.53795-1.7185 0.53795-2.6231 0-2.3519-0.87232-4.0505-2.6169-5.0958-0.61957-0.36183-1.2637-0.5426-1.9322-0.5426z" display="inline" fill="url(#c)"/>
+  <path d="m49.294 35.398c-1.2228 0-2.2824 0.52259-3.1791 1.5679-0.92935 1.1056-1.3942 2.4422-1.3942 4.0101 0 1.8895 0.61168 3.4074 1.8345 4.5532 0.79892 0.74375 1.6957 1.1157 2.6903 1.1157 1.8587 0 3.2119-0.99531 4.0597-2.9854 0.3587-0.84426 0.53795-1.7185 0.53795-2.6231 0-2.372-0.87232-4.0706-2.6169-5.0958-0.61957-0.36182-1.2637-0.5426-1.9322-0.5426z" display="inline" fill="url(#e)"/>
+ </g>
 </svg>


### PR DESCRIPTION
Gets rid of the white outline that looked bad on a dark background. Should look OK in both light and dark themes now. Also added some gradient. Gradient is harder to get right, which is why I had only flat color before. Hope I didn't overdo it. The `i` is supposed to be ambiguous with a colon, but it didn't look enough like an `i` before. New gradient should suggest that shape without changing its footprint. Also the `H` should look like parentheses. These are suggestive of the hotword and s-expression syntax of Hissp's two readers.