### PR TITLE
Macro edge cases

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1020,11 +1020,9 @@ but is completely unlike Clojure.
 And it does have a cost:
 Unlike Clojure's syntax quote,
 there are cases when the way Lissp's template quote should qualify a symbol is ambiguous.
-When neither a function nor a macro has yet been declared for an identifier,
-which way should it be qualified?
-What if both have?
-Try it.
-These template-quote qualification rules mostly just work,
+The same symbol might refer to a builtin, a macro, and a global,
+each of which would have to be qualified differently.
+The template-quote qualification rules were designed to mostly just work,
 but you may run into edge cases in Lissp that couldn't exist in Clojure.
 
 If you wanted semantics more like a Lisp-2,

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -21,7 +21,7 @@ from itertools import chain, takewhile
 from pprint import pformat
 from traceback import format_exc
 from types import ModuleType
-from typing import Iterable, List, Optional, Tuple, TypeVar
+from typing import Iterable, List, NewType, Tuple, TypeVar, Union
 from warnings import warn
 
 PAIR_WORDS = {":*": "*", ":**": "**", ":?": ""}
@@ -36,6 +36,9 @@ RE_MACRO = re.compile(rf"(\.\.{MACROS}\.|\.\.xAUTO_\.)")
 # Rather than pass in an implicit argument, it's available here.
 # readerless() uses this automatically.
 NS = ContextVar("NS", default=())
+
+Sentinel = NewType('Sentinel', object)
+_SENTINEL = Sentinel(object())
 
 
 class CompileError(SyntaxError):
@@ -143,17 +146,18 @@ class Compiler:
     @_trace
     def invocation(self, form: Tuple) -> str:
         """Try to compile as macro, else normal call."""
-        if result := self.macro(form):
+        if (result := self.macro(form)) is not _SENTINEL:
             return f"# {form[0]}\n{result}"
         form = form[0].replace("..xAUTO_.", "..", 1), *form[1:]
         return self.call(form)
 
     @_trace
-    def macro(self, form: Tuple) -> Optional[str]:
+    def macro(self, form: Tuple) -> Union[str, Sentinel]:
         head, *tail = form
         if (macro := self._get_macro(head)) is not None:
             with self.macro_context():
                 return self.form(macro(*tail))
+        return _SENTINEL
 
     def _get_macro(self, head):
         parts = RE_MACRO.split(head, 1)

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -163,17 +163,14 @@ class Compiler:
         parts = RE_MACRO.split(head, 1)
         head = head.replace("..xAUTO_.", MACRO, 1)
         if len(parts) > 1:
-            macro = self._qualified_macro(head, parts)
-        else:
-            macro = self._unqualified_macro(head)
-        return macro
+            return self._qualified_macro(head, parts)
+        return self._unqualified_macro(head)
 
     def _qualified_macro(self, head, parts):
         try:
             if parts[0] == self.qualname:  # Internal?
                 return vars(self.ns[MACROS])[parts[2]]
-            else:
-                return eval(self.symbol(head))
+            return eval(self.symbol(head))
         except (KeyError, AttributeError):
             if parts[1] != "..xAUTO_.":
                 raise

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -263,7 +263,7 @@ class Lissp:
             return f"{self.qualname}.._macro_.{symbol}"  # Known macro.
         if symbol in dir(builtins) and symbol.split('.', 1)[0] not in self.ns:
             return f"builtins..{symbol}"  # Known builtin, not shadowed (yet).
-        if invocation:  # Could still be a recursive macro.
+        if invocation and '.' not in symbol:  # Could still be a recursive macro.
             return f"{self.qualname}..xAUTO_.{symbol}"
         return f"{self.qualname}..{symbol}"
 

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -260,13 +260,12 @@ class Lissp:
         if re.search(r"^\.|\.$|^quote$|^lambda$|^__import__$|xAUTO\d+_$|\.\.", symbol):
             return symbol  # Not qualifiable.
         if invocation and "_macro_" in self.ns and self._macro_has(symbol):
-            return f"{self.qualname}.._macro_.{symbol}"
-        if symbol in dir(builtins) and symbol not in self.ns:
-            return f"builtins..{symbol}"  # Globals shadow builtins.
-        if not invocation or symbol in self.ns:
-            return f"{self.qualname}..{symbol}"
-        # Name wasn't found, but might be a macro later. Decide at compile time.
-        return f"{self.qualname}..xAUTO_.{symbol}"
+            return f"{self.qualname}.._macro_.{symbol}"  # Known macro.
+        if symbol in dir(builtins) and symbol.split('.', 1)[0] not in self.ns:
+            return f"builtins..{symbol}"  # Known builtin, not shadowed (yet).
+        if invocation:  # Could still be a recursive macro.
+            return f"{self.qualname}..xAUTO_.{symbol}"
+        return f"{self.qualname}..{symbol}"
 
     def _macro_has(self, symbol):
         # The _macro_ interface is not required to implement

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -14,6 +14,8 @@
   "test qualified symbol, with docstring"
   `(enlist 'enlist))
 
+(!#defmacro nil () None)
+
 (!#deftype TestBasic (unittest..TestCase)
   test_same_gensym
   (lambda (self)
@@ -38,6 +40,10 @@
   test_doc
   (lambda (self)
     (.assertEqual self _macro_.tqs2.__doc__ "test qualified symbol, with docstring"))
+
+  test_expand_none
+  (lambda (self)
+    (.assertIsNone self (nil)))
 
   test_let
   (lambda (self)

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -107,6 +107,35 @@ class TestReader(TestCase):
             )],
         )
 
+    @patch("hissp.reader.ENTUPLE", "entuple")
+    def test_auto_qualify_attr(self):
+        self.parser.ns.update(x=SimpleNamespace(y=1), int=SimpleNamespace(float=1))
+        self.assertEqual(
+            [('entuple',
+              ':',
+              ':?',
+              ('quote', '__main__..x.y'),
+              ':?',
+              ('quote', '__main__..x.y')),
+             ('entuple',
+              ':',
+              ':?',
+              ('quote', '__main__..int.x'),
+              ':?',
+              ('quote', '__main__..int.float')),
+             ('entuple', ':', ':?', ('quote', '__main__..xAUTO_.int'), ':?', 1),
+             ('entuple', ':', ':?', ('quote', 'builtins..float'), ':?', 1),
+             ('entuple',
+              ':',
+              ':?',
+              ('quote', '__main__..xAUTO_.x'),
+              ':?',
+              ('quote', '__main__..x'))],
+            [*self.parser.reads(
+                '`(x.y x.y) `(int.x int.float) `(int 1) `(float 1) `(x x)'
+            )],
+        )
+
 EXPECTED = {
 # Numeric
 '''False True''': [False, True],

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -92,6 +92,21 @@ class TestReader(TestCase):
             [*self.parser.reads('`(x x x (y y) (1 z))')],
         )
 
+    @patch("hissp.reader.ENTUPLE", "entuple")
+    def test_no_qualification(self):
+        self.assertEqual(
+            [('entuple', ':', ':?', ('quote', '.x')),
+             ('entuple', ':', ':?', ('quote', 'quote'), ':?', 1),
+             ('entuple', ':', ':?', ('quote', 'lambda'), ':?', ':'),
+             ('quote', '__import__'),
+             ('quote', 'xAUTO0_'),
+             ('quote', 'foo..bar'),
+             ('quote', 'foo.')],
+            [*self.parser.reads(
+                '`(.x) `(quote 1) `(lambda :) `__import__ `xAUTO0_ `foo..bar `foo.'
+            )],
+        )
+
 EXPECTED = {
 # Numeric
 '''False True''': [False, True],

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -65,11 +65,11 @@ class TestReader(TestCase):
         self.parser.ns.update(x=1, y=2, z=3)
         self.assertEqual(
             [('entuple',
-              ':', ':?', ('quote', '__main__..x'),
+              ':', ':?', ('quote', '__main__..xAUTO_.x'),
               ':?', ('quote', '__main__..x'),
               ':?', ('quote', '__main__..x'),
               ':?', ('entuple',
-                     ':', ':?', ('quote', '__main__..y'),
+                     ':', ':?', ('quote', '__main__..xAUTO_.y'),
                      ':?', ('quote', '__main__..y')),
               ':?', ('entuple', ':', ':?', 1, ':?', ('quote', '__main__..z')))
              ],


### PR DESCRIPTION
The quick start has a case where there's a recursive macro that shadows a global. The previous qualification rules didn't work for that example. The invocation position is now only auto-qualified as global only when it's an attribute symbol. Also fixed an edge case where macros that expand to `None` would fail.