### PR TITLE
Pretty-format strings at reader level

### DIFF
--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -11,7 +11,7 @@ from functools import reduce
 from importlib import import_module, resources
 from itertools import chain
 from pathlib import Path, PurePath
-from pprint import pprint
+from pprint import pformat, pprint
 from types import ModuleType
 from typing import Any, Iterable, Iterator, NewType, Optional, Tuple, Union
 
@@ -161,7 +161,7 @@ class Lissp:
         if v[0] == 'b':  # bytes
             yield val
         else:
-            yield f"({val!r})"
+            yield v if (v:=pformat(val)).startswith("(") else f"({v})"
 
     def _macro(self, v):
         with {


### PR DESCRIPTION
The compiler also does this, but now that Lissp strings are no longer read using the quote form, but as a Python injection, we have to pretty-format the injection itself, or all the docstrings in the compiled output will each be on one line again.