### PR TITLE
Raw strings

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -1118,45 +1118,6 @@ and return the rewrite macro in that case, or raise an error otherwise.
 
 .. TODO: Demonstrate in the macro tutorials and link here.
 
-What are the differences among control words, symbols, strings, identifiers, and bytes?
----------------------------------------------------------------------------------------------
-
-These can mean different things at different stages,
-as explained in the tutorial and quickstart.
-
-Lissp goes through multiple stages as it compiles:
-
-- the :doc:`Lissp reader<hissp.reader>` reads it in as Hissp data structures.
-
-  - `its lexer<hissp.reader.Lexer>` breaks the text into a stream of tokens.
-  - `its parser<hissp.reader.Lissp>` builds the tokens into Hissp.
-- the :doc:`Hissp compiler<hissp.compiler>` translates Hissp to a functional subset of Python.
-
-Then Python takes over and Hissp does not concern itself with this part.
-But CPython goes through a similar process.
-
-For questions about these to make sense,
-you have to say which stage you are talking about.
-
-Lissp has all five
-(control word, symbol, string, identifier, and bytes)
-as distinct concepts.
-The lexer has only string and atom *tokens*.
-Hissp has only string and bytes *values*.
-Python code has only string and bytes *literals*, and identifiers.
-
-In readerless mode,
-you skip the read step and start at the Hissp level.
-(Technically, you still start with text,
-but Python is parsing it for us instead of the reader.)
-
-If something isn't clear,
-experiment with how they transition through these stages.
-
-In the Lissp REPL you enter Lissp and it shows you the generated Python before evaluating it.
-You can see the Hissp level in between these by quoting a form.
-You can see what the lexer is doing by calling it yourself on a string.
-
 What version of Python is required?
 -----------------------------------
 

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -293,6 +293,139 @@ into the Hissp.
 But for a top-level `define` like this, you could have just used
 `exec()<exec>`.
 
+How do I make bytes objects in Lissp?
+-------------------------------------
+
+.. code-block:: REPL
+
+   #> (bytes '(1 2 3))
+   >>> bytes(
+   ...   (1, 2, 3))
+   b'\x01\x02\x03'
+
+Or, if you prefer hexadecimal,
+
+.. code-block:: REPL
+
+   #> (bytes.fromhex "010203")
+   >>> bytes.fromhex(
+   ...   ('010203'))
+   b'\x01\x02\x03'
+
+But that's just numbers. I want ASCII text.
+-------------------------------------------
+
+You do know about the `str.encode` method, don't you?
+
+There's really no bytes literal in Lissp?
+-----------------------------------------
+
+Technically? No.
+
+However, they do work in Python injections:
+
+.. code-block:: REPL
+
+   #> [b'bytes',b'in',b'collection',b'atoms']
+   >>> [b'bytes', b'in', b'collection', b'atoms']
+   [b'bytes', b'in', b'collection', b'atoms']
+
+   #> .#"b'injected bytes literal'"
+   >>> b'injected bytes literal'
+   b'injected bytes literal'
+
+And, if you have the basic macros loaded,
+you can use the `b` reader macro.
+
+.. code-block:: REPL
+
+   #> b#"bytes from reader macro"
+   >>> b'bytes from reader macro'
+   b'bytes from reader macro'
+
+Bytes literals can be implemented fairly easily in terms of a raw string and reader macro.
+That's close enough, right?
+
+Why aren't any escape sequences working in Lissp strings?
+---------------------------------------------------------
+
+Lissp's strings are raw by default.
+Lissp doesn't force you into any particular set of escapes.
+Some kinds of metaprogramming are easier if you don't have to fight Python.
+You're free to implement your own.
+
+I like Python's, thanks. That sounds like too much work!
+--------------------------------------------------------
+
+Python's are still available in injections:
+
+.. code-block:: REPL
+
+   #> .#"'\u263a'"
+   >>> '\u263a'
+   '☺'
+
+Or use the escape-string read syntax for short:
+
+.. code-block:: REPL
+
+   #> #"\u263a"
+   >>> ('☺')
+   '☺'
+
+Wait, hash strings take escapes? Why are raw strings the default? In Clojure it's the other way around.
+-------------------------------------------------------------------------------------------------------
+
+Then we'd have to write byte strings like this: ``b##"spam"``.
+Python has various other prefixes for string types.
+Raw, bytes, format, unicode, and various combinations of these.
+Reader macros let us handle these in a unified way in Lissp and create more as needed,
+such as regex patterns, among many other types that can be initialized with a single string,
+and that makes raw strings the most sensible default.
+With a supporting reader macro all of these are practically literals.
+It's easy to process escapes in reader macros.
+It isn't easy to unprocess them.
+Not to mention Python code injections,
+which can contain their own strings with escapes.
+
+Clojure's hash strings are already regexes, not raws,
+and their reader macros aren't so easy to use,
+so it doesn't come up as much.
+
+This was not an easy decision.
+Despite all of the above,
+Python string escapes are used quite often.
+
+Why can't I make a backslash character string?
+----------------------------------------------
+
+You can.
+
+.. code-block:: REPL
+
+   #> (len #"\\")
+   >>> len(
+   ...   ('\\'))
+   1
+
+The Lissp tokenizer assumes backslashes are paired in strings,
+so you can't do it with a raw string:
+
+.. code-block:: REPL
+
+   #> (len "\\")
+   >>> len(
+   ...   ('\\\\'))
+   2
+
+   #> "\"
+   #..\\"
+   >>> ('\\"\n\\\\')
+   '\\"\n\\\\'
+
+Python makes the same assumption, even for raw strings.
+So raw strings in Python have the same limitation.
+
 How do I start the REPL again?
 ------------------------------
 
@@ -373,7 +506,9 @@ See also `itertools`, `iter`.
 There's no ``if`` statement. Branching is fundamental!
 ------------------------------------------------------
 
-No it's not. You already learned how to ``for`` loop above. Isn't
+No, it's *really* not.
+(I saw a working C compiler that only output mov instructions.)
+You already learned how to ``for`` loop above. Isn't
 looping zero or one times like skipping a branch or not? Note that
 ``False`` and ``True`` are special cases of ``0`` and ``1`` in Python.
 ``range(False)`` would loop zero times, but ``range(True)`` loops one

--- a/docs/lex.py
+++ b/docs/lex.py
@@ -17,15 +17,15 @@ class LisspLexer(RegexLexer):
 
     tokens = {
         'root': [
-            (r'([(])(lambda|quote)', bygroups(pt.Punctuation, pt.Keyword)),
-            (r'[()]', pt.Punctuation),
-            (r'b?"(?:[^"\\]|\\(?:.|\n))*"', pt.String),
             (r';;;;.*', pt.Generic.Heading),
             (r';;;.*', pt.Generic.Subheading),
             (r';.*', pt.Comment),
             (r'[\n ]+', pt.Text),
             (r'\s|\r', pt.Error),
+            (r'([(])(lambda|quote)', bygroups(pt.Punctuation, pt.Keyword)),
+            (r'[()]', pt.Punctuation),
             (r''',@|['`,]|$#|.#|_#''', pt.Operator),
+            (r'#?"(?:[^"\\]|\\(?:.|\n))*"', pt.String),
             (r'''(?:[^\\ \n"();#]|\\.)+[#]''', pt.Operator.Word),
 
             # Python numbers
@@ -41,7 +41,7 @@ class LisspLexer(RegexLexer):
             (r':[^ \n"()]*', pt.String.Symbol),  # :control-words
 
             (r'''[[{](:?[^\\ \n"();]|\\.)*''', pt.Literal),
-            (r'''(:?[^\\ \n"();]|\\.)+''', pt.Name.Variable),
+            (r'''(:?[^\\ \n"();]|\\.)+''', pt.Name),
         ]
     }
 

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -98,23 +98,18 @@ Lissp Quick Start
    '\\                                    ;'xBSLASH_
    '\a\b\c                                ;Escapes allowed, but not required here.
 
-   "string"                               ;Double-quotes only!
+   "raw string"                           ;Double-quotes only!
    'not-string'                           ;'notxH_stringx1QUOTE_ symbol.
+   #"string\nwith\nescape\nsequences"     ;Not raw.
+   #"Say \"Cheese!\" \u263a"              ;Same backslash escape sequences as Python.
 
    "string
    with
    newlines
-   "                                      ;Same as "string\nwith\nnewlines\n". No triple quotes.
+   "                                      ;Same as #"string\nwith\nnewlines\n". No triple quotes.
 
-   "Say \"Cheese!\""                      ;Same backslash escape sequences as Python.
-
-   b"bytes"                               ;Double-quotes only! Little 'b' only!
-   b'bytes'                               ;NameError: name 'bx1QUOTE_bytesx1QUOTE_' is not defined
-
-   b"bytes
-   with
-   newlines
-   "                                      ;Same as b"bytes\nwith\nnewlines\n".
+   "one\"
+   string\\"                              ;Tokenizer expects paired \'s, even in raw strings.
 
    ;;;; CALLS
 
@@ -160,7 +155,7 @@ Lissp Quick Start
    (lambda (:))                           ;Explicit : is still allowed with no parameters.
    (lambda :)                             ;Thunk idiom.
    (lambda :x1)                           ;Control words are strings are iterable.
-   (lambda b"")                           ; Parameters are not strictly required to be a tuple.
+   (lambda "")                            ; Parameters are not strictly required to be a tuple.
    ((lambda abc                           ;Three parameters.
       (print c b a))
     3 2 1)
@@ -272,6 +267,11 @@ Lissp Quick Start
 
    (list `(1 ,(+ 1 1) 3))
    (set '(1 2 3))
+
+   (bytes '(98 121 116 101 115))
+   (bytes.fromhex "6279746573")
+   .#"b'bytes'"                           ;bytes string from Python injection
+
    (dict (zip '(1 2 3) "abc"))
 
    (dict : + 0  a 1  b 2)                 ;symbolic keys
@@ -454,6 +454,16 @@ Lissp Quick Start
    ;; Imports a copy of hissp.basic.._macro_ (if available)
    ;; and star imports from operator and itertools.
    (b/#prelude)
+
+   ;;; reader
+
+   b#"bytes"                               ;Bytes reader macro.
+   b'bytes'                                ;NameError: name 'bx1QUOTE_bytesx1QUOTE_' is not defined
+
+   b#"bytes
+   with
+   newlines
+   "                                      ;Same as b#"bytes\nwith\nnewlines\n".
 
    ;;; definition
 

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -1852,7 +1852,7 @@ This should not be hard.
 It would require munging,
 with the tradeoffs that entails for Python interop or other Hissp readers.
 Python already has an operator named ``%``.
-If you want to assign `mod` that name, then you might want to stick with the ``X``,
+If you want to assign `mod <operator.mod>` that name, then you might want to stick with the ``X``,
 or remove the special case aliasing ``%1`` to ``%``.
 Also, rather than ``%&`` for the catch-all as in Clojure,
 a ``%*`` might be more consistent if you've also got a kwargs parameter,

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -65,7 +65,7 @@ not a reference,
 and I'll be explaining not just how to write macros,
 but why you need them.
 
-****
+----
 
 If you're new to Lisp,
 go back and read the style guide if you haven't already.
@@ -1104,6 +1104,13 @@ Also, we're kind of running out of alphabet when we start on ``X``,
 You often see 4-D vectors labeled (x, y, z, w),
 but beyond that, mathematicians just number them with subscripts.
 
+We got around this by starting at ``A`` instead,
+but then we're using up all of the uppercase ASCII one-character names.
+We might want to save those for other things.
+We're also limited to 26 parameters this way.
+It's rare we'd need more than three or four,
+but 26 seems kind of arbitrary.
+
 So a better approach might be with numbered parameters, like ``X1``, ``X2``, ``X3``, etc.
 Then, if you macro is smart enough,
 it can look for the highest X-number in your expression
@@ -1470,10 +1477,481 @@ Let's try again.
 
 That's better.
 
-.. (defmacro % (: :* expr)
-     `(lambda ,params (,@expr))
+Function Literals
+~~~~~~~~~~~~~~~~~
 
+Let's review. The code you need to make the version we have so far is
+
+.. code-block:: Lissp
+
+   (hissp.basic.._macro_.prelude)
+
+   (defmacro L (: :* expr)
+     `(lambda ,(map (lambda (i)
+                      (.format "X{}" i))
+                    (range 1 (add 1 (max-X expr))))
+        ,expr))
+
+   (define max-X
+     (lambda (expr)
+       (max (map (lambda (x)
+                   (|| (when (is_ str (type x))
+                         (let (match (re..fullmatch "X([1-9][0-9]*)" x))
+                           (when match
+                             (int (.group match 1)))))
+                       0))
+                 (flatten expr)))))
+
+   (define flatten
+     (lambda (form)
+       (.flatten (Flattener) form)))
+
+   (deftype Flattener ()
+     __init__
+     (lambda (self)
+       (setattr self 'acc []))
+     flatten
+     (lambda (self form)
+       (any-for x form
+         (if-else (is_ (type x) tuple)
+           (self.flatten x)
+           (.append self.acc x))
+         False)
+       self.acc))
+
+You should have all of these definitions in your Lissp file so far.
+
+You can use the resulting macro as a shorter lambda for higher-order functions:
+
+.. code-block:: REPL
+
+   #> (list (map (L add X1 X1) (range 10)))
+   >>> list(
+   ...   map(
+   ...     # L
+   ...     (lambda X1:
+   ...       add(
+   ...         X1,
+   ...         X1)),
+   ...     range(
+   ...       (10))))
+   [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+
+It's still a little awkward.
+It feels like the ``add`` should be in the function position,
+but that's taken by the ``L``.
+We can fix that with a reader macro.
+
+Reader syntax
+`````````````
+
+.. code-block:: REPL
+
+   #> (defmacro X (expr)
+   #..  `(L ,@expr))
+   >>> # defmacro
+   ... # hissp.basic.._macro_.let
+   ... (lambda _fnxAUTO7_=(lambda expr:
+   ...   (lambda *xAUTO0_:xAUTO0_)(
+   ...     '__main__.._macro_.L',
+   ...     *expr)):(
+   ...   __import__('builtins').setattr(
+   ...     _fnxAUTO7_,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_', 'X'))),
+   ...   __import__('builtins').setattr(
+   ...     _macro_,
+   ...     'X',
+   ...     _fnxAUTO7_))[-1])()
+
+Notice we still used a `defmacro`.
+It's the way you invoke it that makes it happen at read time:
+
+.. code-block:: REPL
+
+   #> (list (map X#(add X1 X1) (range 10)))
+   >>> list(
+   ...   map(
+   ...     # __main__.._macro_.L
+   ...     (lambda X1:
+   ...       add(
+   ...         X1,
+   ...         X1)),
+   ...     range(
+   ...       (10))))
+   [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+
+You can invoke any one-argument macro at read time this way.
+Reader macros like this effectively create new read syntax
+by reinterpreting existing read syntax.
+
+So now we have function literals.
+
+This is now very similar to the function literals in Clojure,
+and we implemented them from scratch in about a page of code.
+That's the power of metaprogramming.
+You can copy features from other languages,
+tweak them, and experiment with your own.
+
+Clojure's version still has a couple more features.
+Let's add them.
+
+Catch-all parameter
+```````````````````
+
+.. code-block:: REPL
+
+   #>    (defmacro L (: :* expr)
+   #..     `(lambda (,@(map (lambda (i)
+   #..                        (.format "X{}" i))
+   #..                      (range 1 (add 1 (max-X expr))))
+   #..               :
+   #..               ,@(when (contains (flatten expr)
+   #..                                 'Xi)
+   #..                   `(:* ,'Xi)))
+   #..        ,expr))
+   >>> # defmacro
+   ... # hissp.basic.._macro_.let
+   ... (lambda _fnxAUTO7_=(lambda *expr:
+   ...   (lambda *xAUTO0_:xAUTO0_)(
+   ...     'lambda',
+   ...     (lambda *xAUTO0_:xAUTO0_)(
+   ...       *map(
+   ...         (lambda i:
+   ...           ('X{}').format(
+   ...             i)),
+   ...         range(
+   ...           (1),
+   ...           add(
+   ...             (1),
+   ...             maxxH_X(
+   ...               expr)))),
+   ...       ':',
+   ...       *# when
+   ...       # hissp.basic.._macro_.ifxH_else
+   ...       (lambda test,*thenxH_else:
+   ...         __import__('operator').getitem(
+   ...           thenxH_else,
+   ...           __import__('operator').not_(
+   ...             test))())(
+   ...         contains(
+   ...           flatten(
+   ...             expr),
+   ...           'Xi'),
+   ...         (lambda :
+   ...           # hissp.basic.._macro_.progn
+   ...           (lambda :
+   ...             (lambda *xAUTO0_:xAUTO0_)(
+   ...               ':*',
+   ...               'Xi'))()),
+   ...         (lambda :()))),
+   ...     expr)):(
+   ...   __import__('builtins').setattr(
+   ...     _fnxAUTO7_,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_', 'L'))),
+   ...   __import__('builtins').setattr(
+   ...     _macro_,
+   ...     'L',
+   ...     _fnxAUTO7_))[-1])()
+
+   #> (X#(print X1 X2 Xi) 1 2 3 4 5)
+   >>> # __main__.._macro_.L
+   ... (lambda X1,X2,*Xi:
+   ...   print(
+   ...     X1,
+   ...     X2,
+   ...     Xi))(
+   ...   (1),
+   ...   (2),
+   ...   (3),
+   ...   (4),
+   ...   (5))
+   1 2 (3, 4, 5)
+
+How does it work? Look at what's changed. Here it is again.
+
+.. code-block:: Lissp
+
+   (defmacro L (: :* expr)
+     `(lambda (,@(map (lambda (i)
+                        (.format "X{}" i))
+                      (range 1 (add 1 (max-X expr))))
+               :
+               ,@(when (contains (flatten expr)
+                                 'Xi)
+                   `(:* ,'Xi)))
+        ,expr))
+
+We splice in the old logic into the new parameters tuple to make the numbered parameters.
+Following that is the colon separator.
+Remember that it's always allowed in Hissp's lambda forms,
+even if you don't need it,
+which makes this kind of metaprogramming easier.
+
+Following that is the code for a star arg.
+This is an anaphor, so it must be interpolated to prevent qualification.
+Note that the `when` macro will return an empty tuple when its condition is false.
+Attempting to splice in an empty tuple conveniently doesn't do anything
+(this is similar to "nil punning" in other Lisps),
+so the anaphor is only present in the parameters tuple when the expression `contains <operator.contains>` the ``Xi`` anahpor.
+
+Clojure doesn't have these,
+but it would be nice for Python interoperability if we also had a kwargs anaphor.
+Adding this is left as an exercise.
+Can you figure out how to do it?
+
+Implied number 1
+````````````````
+
+Clojure's version has one more feature:
+the name of the first parameter doesn't need the ``1``,
+but it's allowed.
+
+The more special cases you have to add,
+the more complex the macro might get.
+
+Here you go:
+
+.. code-block:: REPL
+
+   #> (defmacro L (: :* expr)
+   #..  `(lambda (,@(map (lambda (i)
+   #..                     (.format "X{}" i))
+   #..                   (range 1 (add 1 (|| (max-X expr)
+   #..                                       (contains (flatten expr)
+   #..                                                 'X)))))
+   #..            :
+   #..            ,@(when (contains (flatten expr)
+   #..                              'Xi)
+   #..                `(:* ,'Xi)))
+   #..     ,(if-else (contains (flatten expr)
+   #..                         'X)
+   #..        `(let (,'X ,'X1)
+   #..           ,expr)
+   #..        expr)))
+   >>> # defmacro
+   ... # hissp.basic.._macro_.let
+   ... (lambda _fnxAUTO7_=(lambda *expr:
+   ...   (lambda *xAUTO0_:xAUTO0_)(
+   ...     'lambda',
+   ...     (lambda *xAUTO0_:xAUTO0_)(
+   ...       *map(
+   ...         (lambda i:
+   ...           ('X{}').format(
+   ...             i)),
+   ...         range(
+   ...           (1),
+   ...           add(
+   ...             (1),
+   ...             # xBAR_xBAR_
+   ...             # hissp.basic.._macro_.let
+   ...             (lambda _firstxAUTO34_=maxxH_X(
+   ...               expr):
+   ...               # hissp.basic.._macro_.ifxH_else
+   ...               (lambda test,*thenxH_else:
+   ...                 __import__('operator').getitem(
+   ...                   thenxH_else,
+   ...                   __import__('operator').not_(
+   ...                     test))())(
+   ...                 _firstxAUTO34_,
+   ...                 (lambda :_firstxAUTO34_),
+   ...                 (lambda :
+   ...                   # hissp.basic..xAUTO_.xBAR_xBAR_
+   ...                   contains(
+   ...                     flatten(
+   ...                       expr),
+   ...                     'X'))))()))),
+   ...       ':',
+   ...       *# when
+   ...       # hissp.basic.._macro_.ifxH_else
+   ...       (lambda test,*thenxH_else:
+   ...         __import__('operator').getitem(
+   ...           thenxH_else,
+   ...           __import__('operator').not_(
+   ...             test))())(
+   ...         contains(
+   ...           flatten(
+   ...             expr),
+   ...           'Xi'),
+   ...         (lambda :
+   ...           # hissp.basic.._macro_.progn
+   ...           (lambda :
+   ...             (lambda *xAUTO0_:xAUTO0_)(
+   ...               ':*',
+   ...               'Xi'))()),
+   ...         (lambda :()))),
+   ...     # ifxH_else
+   ...     (lambda test,*thenxH_else:
+   ...       __import__('operator').getitem(
+   ...         thenxH_else,
+   ...         __import__('operator').not_(
+   ...           test))())(
+   ...       contains(
+   ...         flatten(
+   ...           expr),
+   ...         'X'),
+   ...       (lambda :
+   ...         (lambda *xAUTO0_:xAUTO0_)(
+   ...           '__main__.._macro_.let',
+   ...           (lambda *xAUTO0_:xAUTO0_)(
+   ...             'X',
+   ...             'X1'),
+   ...           expr)),
+   ...       (lambda :expr)))):(
+   ...   __import__('builtins').setattr(
+   ...     _fnxAUTO7_,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_', 'L'))),
+   ...   __import__('builtins').setattr(
+   ...     _macro_,
+   ...     'L',
+   ...     _fnxAUTO7_))[-1])()
+
+   #> (list (map X#(add X X1) (range 10)))
+   >>> list(
+   ...   map(
+   ...     # __main__.._macro_.L
+   ...     (lambda X1:
+   ...       # __main__.._macro_.let
+   ...       (lambda X=X1:
+   ...         add(
+   ...           X,
+   ...           X1))()),
+   ...     range(
+   ...       (10))))
+   [0, 2, 4, 6, 8, 10, 12, 14, 16, 18]
+
+Now both ``X`` and ``X1`` refer to the same value,
+even if you mix them.
+
+Read the macro and its outputs carefully.
+This version uses a bool pun.
+Recall that ``False`` is a special case of ``0``
+and ``True`` is a special case of ``1`` in Python.
+
+The design could be improved a bit.
+You'll probably want some automated test cases before refactoring.
+Writing tests is a little beyond the scope of this lesson,
+but you can use the standard library unit test class in Lissp, just like Python.
+
+There are several repetitions of ``flatten`` and `contains <operator.contains>`.
+Don't worry too much about the efficiency of code that only runs once at compile time.
+What matters is what comes out in the expansions.
+
+You could factor these out using a `let` and local variable.
+But sometimes a terse implementation is the clearest name.
+You might also consider flattening before passing to ``max-X`` instead of letting ``max-X`` do it.
+
+Another thing to consider, you might change the ``X``'s to ``%``'s,
+and then it would really look like Clojure.
+This should not be hard.
+It would require munging,
+with the tradeoffs that entails for Python interop or other Hissp readers.
+Python already has an operator named ``%``.
+If you want to assign `mod` that name, then you might want to stick with the ``X``,
+or remove the special case aliasing ``%1`` to ``%``.
+Also, rather than ``%&`` for the catch-all as in Clojure,
+a ``%*`` might be more consistent if you've also got a kwargs parameter,
+which you could call ``%**``.
+
+Results
+```````
+
+Are we shorter than Python now?
+
+.. code-block:: Text
+
+   lambda x:x*x
    #%(* % %)
+
+Did we lose generality?
+Yes, but not much.
+You can't really nest these.
+The parameters get generated even if the only occurence in the expression is quoted.
+This is the kind of thing to be mindful of.
+If you're not sure about something,
+try it in the REPL.
+But Clojure's version has the same problems,
+and it gets used quite a lot.
+
+Why you should be reluctant to use Python injections
+````````````````````````````````````````````````````
+
+Suppose we wanted to use Python infix notation for a complex formula.
+
+Do you see the problem with this?
+
+.. code-block:: Lissp
+
+   %#(.#"(-%2 + (%2**2 - 4*%1*%3)**0.5)/(2*%1)")
+
+This was supposed to be the quadratic formula.
+The ``%`` is an operator in Python,
+and it can't be unary.
+In an injection you would have to spell it using the munged name ``xPCENT_``.
+But what if we had kept the ``X``?
+
+.. code-block:: REPL
+
+   #> X#(.#"(-X2 + (X2**2 - 4*X1*X3)**0.5)/(2*X1)")
+   >>> # __main__.._macro_.L
+   ... (lambda :(-X2 + (X2**2 - 4*X1*X3)**0.5)/(2*X1)())
+   <function <lambda> at ...>
+
+It looks like we're trying to call the formula.
+We're expecting at least one function in prefix notation.
+
+Maybe we can do the divide in prefix and keep the others infix?
+
+.. code-block:: REPL
+
+   #> X#(truediv .#"(-X2 + (X2**2 - 4*X1*X3)**0.5)" .#"(2*X1)")
+   >>> # __main__.._macro_.L
+   ... (lambda :
+   ...   truediv(
+   ...     (-X2 + (X2**2 - 4*X1*X3)**0.5),
+   ...     (2*X1)))
+   <function <lambda> at ...>
+
+Now the formula looks right,
+but this lambda takes no parameters!
+Python injections hide information that code-reading macros need to work.
+The macro was unable to detect any matching symbols
+because it doesn't look inside the string.
+In principle it *could have*,
+but it might be a lot more work if you want it to be reliable.
+It could function if the parameters also appeared outside the string,
+but at that point, you might as well use a normal lambda.
+
+Regex might be good enough for a simple case like this,
+but even if you write it very carefully,
+are you sure you're catching all the edge cases?
+To really do it right,
+you'd have to *parse the AST*.
+The whole point of using Hissp tuples instead is so you don't have to do this.
+Hissp is a kind of AST with lower complexity.
+
+Arguably, we didn't do it right either since it still detects anaphors even if they're quoted,
+but this level is good enough for Clojure.
+A simple basic syntax means there are relatively few edge cases.
+
+Hissp is so simple that a full code-walking macro would only have to pre-expand all macros,
+and handle atoms, calls, ``quote``, and ``lambda``.
+
+.. TODO: Which we will be demonstrating later!
+
+If you add injections to the list,
+then you also have to handle the entirety of all Python expressions.
+Don't expect Hissp macros to do this.
+Be reluctant to use Python injections,
+and be aware of where they might break things.
+They're mainly useful as performance optimizations.
+In principle,
+you should be able to do everything else without them.
 
 .. TODO: attach
    (defmacro attach (target : :* args)

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -452,7 +452,7 @@ use a dedent string, which can be safely indented:
 
 .. code-block:: REPL
 
-   #> (print (.upper 'textwrap..dedent#"\
+   #> (print (.upper 'textwrap..dedent##"\
    #..               These lines
    #..               Don't interrupt
    #..               the flow."))

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -292,12 +292,36 @@ and do not appear in the output.
 Strings
 #######
 
-Double-quoted strings in Lissp may contain newlines,
-but otherwise behave as Python's and accept the same escape codes:
+Double-quoted strings in Lissp read backslashes and newlines literally,
+which makes them similar to triple-quoted raw strings in Python.
 
 .. code-block:: REPL
 
-    #> "Three
+    #> "Two
+    #..lines\ntotal"
+    >>> ('Two\nlines\\ntotal')
+    'Two\nlines\\ntotal'
+
+Do note, however, that the *tokenizer* expects backslashes to be paired.
+
+.. code-block:: REPL
+
+    #> "\"
+    #..\\"  ; One string, not two!
+    >>> ('\\"\n\\\\')
+    '\\"\n\\\\'
+
+The second double-quote character didn't end the string,
+but the backslash "escaping" it was still read literally.
+The third double quote did end the string despite being adjacent to a backslash,
+because that was already paired with another backslash.
+Again, this is the same as Python's raw strings.
+
+You can enable the processing of Python's backslash escape sequences by prefixing a string with ``#``.
+
+.. code-block:: REPL
+
+    #> #"Three
     #..lines\ntotal"
     >>> ('Three\nlines\ntotal')
     'Three\nlines\ntotal'
@@ -321,7 +345,7 @@ because when quoted it will compile as data, rather than evaluate as code:
     >>> ('lambda', ('name',), ('print', "('Hello')", 'name'))
     ('lambda', ('name',), ('print', "('Hello')", 'name'))
 
-Notice that rather than using the quote special form for "Hello",
+Notice that rather than using the ``quote`` special form for "Hello",
 Lissp reads in a double-quoted string as a Hissp string containing a Python string.
 
 Symbols
@@ -724,7 +748,7 @@ For example:
 
 .. code-block:: REPL
 
-    #> (print 1 2 3 : sep ":"  end "\n.")
+    #> (print 1 2 3 : sep ":"  end #"\n.")
     >>> print(
     ...   (1),
     ...   (2),
@@ -773,7 +797,7 @@ Use the special control words ``:*`` for iterable unpacking,
 
 .. code-block:: REPL
 
-    #> (print : :* '(1 2)  :? 3  :* '(4)  :** (dict : sep :  end "\n."))
+    #> (print : :* '(1 2)  :? 3  :* '(4)  :** (dict : sep :  end #"\n."))
     >>> print(
     ...   *(1, 2),
     ...   (3),
@@ -799,11 +823,6 @@ function name starts with a dot:
     #> (.conjugate 1j)
     >>> (1j).conjugate()
     -1j
-
-    #> (.decode b"\xfffoo" : errors 'ignore)
-    >>> b'\xfffoo'.decode(
-    ...   errors='ignore')
-    'foo'
 
 Reader Macros
 -------------
@@ -853,7 +872,7 @@ And can inject arbitrary text into the compiled output:
 
 .. code-block:: REPL
 
-    #> .#"{(1, 2): \"\"\"buckle my shoe\"\"\"}  # This is Python!"
+    #> .##"{(1, 2): \"\"\"buckle my shoe\"\"\"}  # This is Python!"
     >>> {(1, 2): """buckle my shoe"""}  # This is Python!
     {(1, 2): 'buckle my shoe'}
 

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -151,7 +151,7 @@ judicious use can improve performance and maintainability.
 ;; see also from bootstrap: let
 
 (defmacro import (: :* args)
-  `(print "\
+  `(print #"\
 Nothingness above abstraction
   but implementation is / the best name.
 Terseness may make one too many / get used to them
@@ -292,7 +292,7 @@ but many macros still require this kind of recursive list processing.
 ;;; control flow
 
 (defmacro cond (: :* pairs)
-  "Multiple condition branching.
+  #"Multiple condition branching.
 
   Pairs are implied. Default is (); use :else to change it.
   For example::
@@ -353,6 +353,16 @@ but many macros still require this kind of recursive list processing.
 ;; Note that any of the basic macros with a lambda "body" argument
 ;; also sequence expressions for side effects.
 
+;;; reader
+
+(defmacro b (raw)
+  "bytes literal reader macro"
+  (-> raw
+      (.replace "'" "\'")
+      (.replace #"\n" "\n")
+      (->> (.format "b'{}'"))
+      (ast..literal_eval)))
+
 ;;; import
 
 (defmacro prelude ()
@@ -361,7 +371,7 @@ but many macros still require this kind of recursive list processing.
   Star imports from operator and itertools.
   And adds the basic macros, if available.
   "
-  `(exec "\
+  `(exec #"\
 from operator import *
 from itertools import *
 try:

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -257,7 +257,7 @@
   test_string_newline
   (lambda (self)
     (.assertEqual self
-                  "\
+                  #"\
 foo\
 bar\nbaz"
                   "foobar
@@ -268,7 +268,7 @@ baz")
 foo
 bar
 "
-                  "\n\nfoo\nbar\n"))
+                  #"\n\nfoo\nbar\n"))
 
   test_string_reader_macro
   (lambda (self)

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -152,15 +152,17 @@ def test_repl_str_continue():
 
 x
 "
-b""
-b"foo bar"
-b"
+b#""
+b#"foo bar"
+b#"
 
 
 "
-b"
+b#"
 
 x"
+(.decode b#"\\xff
+foo" : errors 'ignore)
 """,
         r"""#> ''
 #> 'foo bar'
@@ -170,6 +172,7 @@ x"
 #> b'foo bar'
 #> #..#..#..b'\n\n\n'
 #> #..#..b'\n\nx'
+#> #..'\nfoo'
 #> """,
         r""">>> ('')
 >>> ('foo bar')
@@ -179,6 +182,8 @@ x"
 >>> b'foo bar'
 >>> b'\n\n\n'
 >>> b'\n\nx'
+>>> b'\xff\nfoo'.decode(
+...   errors='ignore')
 """,
     )
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -168,11 +168,11 @@ object.__class__.__name__ ; Attributes chain.
     "('string')",
     "('')",
 ],
-'''b""''': [b''],
+'''b""''': ['b', "('')"],
 "b''": ['bx1QUOTE_x1QUOTE_'],
 "b''''''": ['bx1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_x1QUOTE_'],
 '''b""""""''': [
-    b'', "('')", "('')"
+    'b', "('')", "('')", "('')"
 ],
 '''rb'' br'' RB'' BR'' rb"" br"" B"" ''': [
     'rbx1QUOTE_x1QUOTE_',
@@ -186,12 +186,12 @@ object.__class__.__name__ ; Attributes chain.
     'B',
     "('')"
 ],
-'''b"bytes"''': [b'bytes'],
+'''b"not bytes"''': ['b', "('not bytes')"],
 '''\
-b"bytes
+b"not bytes
 with
 newlines"
-''': [b'bytes\nwith\nnewlines'],
+''': ['b', r"('not bytes\nwith\nnewlines')"],
 # invocation
 '''(print "Hello, World!")''': [
     ('print', "('Hello, World!')")


### PR DESCRIPTION
Breaking changes in this one. Lissp strings are now raw by default, but you can turn escapes on with a prefix. No more bytes literals. It's now a (basic) reader macro.

This was mainly motivated by the upcoming lesson on reader macros for the macro tutorial. Regex pattern literals seem like a good candidate. We didn't have raw strings at all before. Regex is awkward when you have to double-escape backslashes, but that's how it's done in Emacs, which has no raw strings and no access to the read table. It would be possible to quote regex characters with something else, like `'` using clever regex find-and-replace, but a lot of other metaprogramming would also get easier with raw strings. The ability to read in arbitrary text is especially important for Lissp because it doesn't give you a hook into the tokenizer. (Common Lisp does, but it's not clear if it's worth it.)

I briefly toyed with various kinds of multiline raw strings that would have been close enough to Emacs Lisp syntax to be workable with Emacs and Parinfer (read in from `;;`-comments delimited with `#;`/`#`), but it really didn't work very well with Paredit. Bytes literals kind of had a similar problem, but hash strings like Clojure's regex literals don't (`#"foo"`), so I considered using those for raws.

But doing it the other way around seems better: `"foo"` is raw and `#"foo"` does escapes. I've filled in my reasoning about this more in the FAQ.