### PR TITLE
Reader macro continue

### DIFF
--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -229,7 +229,7 @@ Lissp Quick Start
    ''x                                    ;('quote', 'x')
    '\'x                                   ;'x1QUOTE_x'
 
-   (print (.upper 'textwrap..dedent#"\
+   (print (.upper 'textwrap..dedent##"\
                   These lines
                   Don't interrupt
                   the flow."))

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -177,9 +177,12 @@ class Lissp:
             ",@": self.unquote_context,
         }.get(v, nullcontext)():
             try:
+                depth = self.depth
                 form = next(self.parse(self.tokens))
             except StopIteration:
-                raise SoftSyntaxError(f"Reader macro {v!r} missing argument.", self.position()) from None
+                if self.depth == depth:
+                    raise SoftSyntaxError(f"Reader macro {v!r} missing argument.", self.position()) from None
+                raise SyntaxError(f"Reader macro {v!r} missing argument.", self.position()) from None
             yield self.parse_macro(v, form)
 
     @staticmethod

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -179,7 +179,7 @@ class Lissp:
             try:
                 form = next(self.parse(self.tokens))
             except StopIteration:
-                raise SyntaxError(f"Reader macro {v!r} missing argument.", self.position()) from None
+                raise SoftSyntaxError(f"Reader macro {v!r} missing argument.", self.position()) from None
             yield self.parse_macro(v, form)
 
     @staticmethod


### PR DESCRIPTION
Minor bug fix. Reader macros don't usually have whitespace after them, but it's allowed. Failing to complete this pair is a condition that could be corrected with more lines of input so it is a soft syntax error.

I also missed a raw string that needed escapes in the quickstart. I need to figure out how to test these.