### PR TITLE
clean up doc tables

### DIFF
--- a/docs/hissp.rst
+++ b/docs/hissp.rst
@@ -11,6 +11,7 @@ Submodules
    hissp.compiler
    hissp.munger
    hissp.reader
+   hissp.repl
 
 Module contents
 ---------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,17 +26,20 @@ or read the more detailed tutorial.
    macro_tutorial
    command_line_reference
 
-* :ref:`API Reference <modindex>`
+.. toctree::
+   :maxdepth: 3
+
+   API <hissp>
 
 .. toctree::
    :maxdepth: 1
 
    faq
 
-* :ref:`genindex`
-
 ****
 
 .. toctree::
 
    GitHub Repository <https://github.com/gilch/hissp>
+
+* :ref:`genindex`

--- a/docs/modules.rst
+++ b/docs/modules.rst
@@ -1,7 +1,0 @@
-hissp
-=====
-
-.. toctree::
-   :maxdepth: 4
-
-   hissp


### PR DESCRIPTION
Search page isn't working, but Furo theme has a search bar.
Index is working now.
Module index isn't, but a direct link to pages generated by apidoc are an acceptable substitute.