### PR TITLE
fix bad install path

### DIFF
--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -344,7 +344,7 @@ Lissp Quick Start
    #..         e 1  f 2                      ;default
    #..         :* args  h 4  i :?  j 1       ;star args, key word
    #..         :** kwargs)
-   #..  ;; Body. (Lambdas returns empty tuple if body is empty.)
+   #..  ;; Body. (Lambdas return empty tuple when body is empty.)
    #..  (print (globals))
    #..  (print (locals))                     ;side effects
    #..  b)                                   ;last value is returned

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -53,7 +53,7 @@ Hissp requires Python 3.8+ and has no other dependencies.
 
 Install the Hissp version matching this document with::
 
-   $ pip install git+https://github.com/gilch
+   $ pip install git+https://github.com/gilch/hissp
 
 
 Hello World


### PR DESCRIPTION
Fix the incomplete URL in the tutorial. It's the same mistake as before in the quick start.