### PR TITLE
More macro tutorial

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -49,14 +49,12 @@ class ParseLissp(DocTestParser):
             parser.compiler.ns = example.namespace
             hissp = parser.reads(lissp)
             compiled = parser.compiler.compile(hissp) + "\n"
-            assert norm_gensym_eq(compiled, python), dedent(
-                f"""
-                EXPECTED PYTHON:
-                {indent(python, "  ")}
-                ACTUALLY COMPILED TO:
-                {indent(compiled, "  ")}
-                .
-                """
+            from difflib import context_diff
+            assert norm_gensym_eq(compiled, python), ''.join(
+                context_diff(
+                    indent(python, "  ").splitlines(True),
+                    indent(compiled, "  ").splitlines(True),
+                )
             )
         return super().evaluate(example)
 

--- a/conftest.py
+++ b/conftest.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Container
 from doctest import ELLIPSIS
 from fnmatch import fnmatch
-from textwrap import dedent, indent
+from textwrap import indent
 
 from sybil import Sybil
 from sybil.parsers.doctest import DocTestParser

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -680,7 +680,7 @@ But I have to already have an iterable, which is why I wanted a tuple in the fir
 
 You can also make an empty list with ``[]`` or ``(list)``,
 and then ``.append`` to it.
-(Try the `cascade` macro.)
+(Try the `doto` macro.)
 
 Finally, the template syntax :literal:`\`()` makes tuples.
 Beware of auto-qualification and string reader syntax

--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -871,7 +871,8 @@ Like this
    ...    '    from hissp.basic import _macro_\n'
    ...    "    _macro_ = __import__('types').SimpleNamespace(**vars(_macro_))\n"
    ...    'except ModuleNotFoundError:\n'
-   ...    '    pass'))
+   ...    '    pass'),
+   ...   __import__('builtins').globals())
 
 
    #> (deftype Except (contextlib..ContextDecorator)

--- a/docs/lex.py
+++ b/docs/lex.py
@@ -9,6 +9,7 @@ SN = r'[+-]?'
 Ds = r'(?:\d(?:_?\d)*)'
 Es = rf'(?:[Ee]{SN}{Ds})'
 
+
 # TODO: rename file?
 class LisspLexer(RegexLexer):
     name = 'Lissp'
@@ -37,13 +38,14 @@ class LisspLexer(RegexLexer):
             (rf'{SN}0[xX](?:_?[a-fA-F0-9])+', pt.Number.Hex),
             (rf'{SN}{Ds}', pt.Number.Integer),
 
-            ('None|\.\.\.', pt.Name.Builtin),
+            (r'None|\.\.\.', pt.Name.Builtin),
             (r':[^ \n"()]*', pt.String.Symbol),  # :control-words
 
             (r'''[[{](:?[^\\ \n"();]|\\.)*''', pt.Literal),
             (r'''(:?[^\\ \n"();]|\\.)+''', pt.Name),
         ]
     }
+
 
 class LisspReplLexer(RegexLexer):
     tokens = {

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -1420,7 +1420,8 @@ Lissp Quick Start
    ...    '    from hissp.basic import _macro_\n'
    ...    "    _macro_ = __import__('types').SimpleNamespace(**vars(_macro_))\n"
    ...    'except ModuleNotFoundError:\n'
-   ...    '    pass'))
+   ...    '    pass'),
+   ...   __import__('builtins').globals())
 
 
    ;;; Reader

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -1577,20 +1577,18 @@ Lissp Quick Start
    ...   _targetxAUTO16_)[-1])()
    namespace(a=1, b='Hi', xPLUS_=<built-in function add>)
 
-   #> (cascade []
+   #> (doto []
    #..  (.extend "bar")
    #..  (.sort)
-   #..  (.append "foo")
-   #..  (progn))
-   >>> # cascade
+   #..  (.append "foo"))
+   >>> # doto
    ... (lambda _selfxAUTO20_=[]:(
    ...   _selfxAUTO20_.extend(
    ...     ('bar')),
    ...   _selfxAUTO20_.sort(),
    ...   _selfxAUTO20_.append(
    ...     ('foo')),
-   ...   # progn
-   ...   (lambda :_selfxAUTO20_)())[-1])()
+   ...   _selfxAUTO20_)[-1])()
    ['a', 'b', 'r', 'foo']
 
 

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -2281,8 +2281,8 @@ which many Lisps include.
 Other languages made other selections,
 which may make them more or less convenient for certain problem domains.
 
-Would an ideal language then have a notation for every conceivable "primitive"?
-I say no.
+What notations would an ideal language have?
+Every conceivable "primitive"?
 Such a language would be more difficult to learn.
 It's much easier to familiarize oneself with a small set of primitive notations,
 and the means of combination.

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -2798,6 +2798,9 @@ It would be nice if the macro could deal with it for us,
 but there's just no getting around these issues when using a float.
 Lissp reader macros get the parsed object,
 and by then, some information has been lost.
+One could argue that a float literal written with more precision than is
+available should be a syntax error,
+but Python doesn't care.
 
 In cases like this,
 it's best to not use a float at all,

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -2651,8 +2651,196 @@ Or you can add floating-point. Python's notation can't do that.
    >>> (3.0)
    3.0
 
+Decimal
+~~~~~~~
 
-.. TODO: Decimal
+Floating-point numbers are very useful,
+but they have some important limitations.
+
+.. code-block:: Python
+
+   >>> 0.2 * 3
+   0.6000000000000001
+
+Not quite what you expected?
+Binary floating-point can't represent exact fifths like decimal can.
+For exact decimals, you need decimal floating-point.
+
+.. code-block:: REPL
+
+   #> (mul (decimal..Decimal "0.2") 3)
+   >>> mul(
+   ...   __import__('decimal').Decimal(
+   ...     ('0.2')),
+   ...   (3))
+   Decimal('0.6')
+
+Because it takes a single string argument,
+you can already use `decimal.Decimal` as a reader macro:
+
+.. code-block:: REPL
+
+   #> (mul decimal..Decimal#".2" 3)
+   >>> mul(
+   ...   __import__('pickle').loads(  # Decimal('0.2')
+   ...       b'cdecimal\nDecimal\n(V0.2\ntR.'
+   ...   ),
+   ...   (3))
+   Decimal('0.6')
+
+It's kind of long though.
+
+Notice that Hissp had to use a pickle here,
+because it had to emit code for the object,
+but Python has no literal notation for Decimal objects.
+
+The reader macro didn't inject the code for making a Decimal,
+but an actual Decimal object, at read time.
+The pickling isn't done by the reader.
+It doesn't happen until the compiler has to emit something
+that it doesn't have a round-tripping representation for.
+
+Something like this never goes through a pickle.
+
+.. code-block:: REPL
+
+   #> 'builtins..repr#decimal..Decimal#".2"
+   >>> "Decimal('0.2')"
+   "Decimal('0.2')"
+
+It changed to a string before the compiler had to emit it.
+
+Decimal can also take float objects,
+but this isn't always a good idea.
+
+.. code-block:: REPL
+
+   #> decimal..Decimal#.2
+   >>> __import__('pickle').loads(  # Decimal('0.200000000000000011102230246251565404236316680908203125')
+   ...     b'cdecimal\nDecimal\n(V0.200000000000000011102230246251565404236316680908203125\ntR.'
+   ... )
+   Decimal('0.200000000000000011102230246251565404236316680908203125')
+
+There's no bug in Decimal.
+That's just the exact binary fraction closest to one-fifth,
+given the available precision in a float,
+when represented as a decimal.
+
+Maybe we could work around this if we converted to a string first?
+We can improve this a lot with a custom defmacro.
+
+.. Lissp::
+
+   #> (defmacro \10\# (x)
+   #..  `(decimal..Decimal ',(str x)))
+   >>> # defmacro
+   ... # hissp.basic.._macro_.let
+   ... (lambda _fnxAUTO7_=(lambda x:
+   ...   (lambda * _: _)(
+   ...     'decimal..Decimal',
+   ...     (lambda * _: _)(
+   ...       'quote',
+   ...       str(
+   ...         x)))):(
+   ...   __import__('builtins').setattr(
+   ...     _fnxAUTO7_,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_',
+   ...        'xDIGITxONE_0xHASH_',))),
+   ...   __import__('builtins').setattr(
+   ...     __import__('operator').getitem(
+   ...       __import__('builtins').globals(),
+   ...       '_macro_'),
+   ...     'xDIGITxONE_0xHASH_',
+   ...     _fnxAUTO7_))[-1])()
+
+.. code-block:: REPL
+
+   #> 10#.2
+   >>> __import__('decimal').Decimal(
+   ...   '0.2')
+   Decimal('0.2')
+
+This is better.
+It's a much shorter notation;
+there are no extra digits after the 2;
+and (because we used a template)
+it compiled to the straightforward code for a Decimal,
+rather than a pickle.
+This makes the compiled output a bit easier to read,
+but using code like this, rather than the Decimal object itself,
+may make it less useful as input to other macros.
+Which approach is better depends on your needs.
+
+But there's still a subtle problem:
+
+.. code-block:: REPL
+
+   #> 10#.1234567890_1234567890_000
+   >>> __import__('decimal').Decimal(
+   ...   '0.12345678901234568')
+   Decimal('0.12345678901234568')
+
+   #> 10#".1234567890_1234567890_000"
+   >>> __import__('decimal').Decimal(
+   ...   '.1234567890_1234567890_000')
+   Decimal('0.12345678901234567890000')
+
+We have limited precision when tagging a float instead of a string.
+If you don't need the precision, it's fine.
+If you do, you can still use a string,
+but you have to be aware of this.
+Decimal also keeps trailing zeros to represent significant figures.
+But floats never do this, even when the precision is available.
+
+It would be nice if the macro could deal with it for us,
+but there's just no getting around these issues when using a float.
+Lissp reader macros get the parsed object,
+and by then, some information has been lost.
+
+In cases like this,
+it's best to not use a float at all,
+but a string is not the only alternative available:
+
+.. Lissp::
+
+   #> (defmacro \10\# (x)
+   #..  `(decimal..Decimal ',(getitem x (slice 1 None))))
+   >>> # defmacro
+   ... # hissp.basic.._macro_.let
+   ... (lambda _fnxAUTO7_=(lambda x:
+   ...   (lambda * _: _)(
+   ...     'decimal..Decimal',
+   ...     (lambda * _: _)(
+   ...       'quote',
+   ...       getitem(
+   ...         x,
+   ...         slice(
+   ...           (1),
+   ...           None))))):(
+   ...   __import__('builtins').setattr(
+   ...     _fnxAUTO7_,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_',
+   ...        'xDIGITxONE_0xHASH_',))),
+   ...   __import__('builtins').setattr(
+   ...     __import__('operator').getitem(
+   ...       __import__('builtins').globals(),
+   ...       '_macro_'),
+   ...     'xDIGITxONE_0xHASH_',
+   ...     _fnxAUTO7_))[-1])()
+
+.. code-block:: REPL
+
+   #> 10#:.1234567890_1234567890_000
+   >>> __import__('decimal').Decimal(
+   ...   '.1234567890_1234567890_000')
+   Decimal('0.12345678901234567890000')
+
+With a control word like this,
+you get full precision and don't need a trailing double quote.
 
 .. TODO: fractions
    (defmacro F\# (x)

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -231,7 +231,8 @@ And push it to the REPL as well:
    ...    '    from hissp.basic import _macro_\n'
    ...    "    _macro_ = __import__('types').SimpleNamespace(**vars(_macro_))\n"
    ...    'except ModuleNotFoundError:\n'
-   ...    '    pass'))
+   ...    '    pass'),
+   ...   __import__('builtins').globals())
 
 .. caution::
 

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", encoding="utf8") as f:
     long_description = f.read()
 
 import sys
-sys.path.insert(0,'src')
+sys.path.insert(0, 'src')
 import hissp.reader
 hissp.reader.transpile(hissp.__package__, "basic")
 

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -361,7 +361,7 @@ meditate on this.
 
 ;;; import
 
-(defmacro prelude ()
+(defmacro prelude (: ns `(globals))
   "Grants unqualified access to the basics.
 
   Star imports from `operator` and `itertools`.
@@ -376,7 +376,8 @@ try:
     from hissp.basic import _macro_
     _macro_ = __import__('types').SimpleNamespace(**vars(_macro_))
 except ModuleNotFoundError:
-    pass"))
+    pass"
+    ,ns))
 
 (defmacro alias (alias module)
   "Defines a reader macro abbreviation of a symbol prefix

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -223,11 +223,13 @@ meditate on this.
                 iargs)
          ,$target))))
 
-(defmacro cascade (self : :* invocations)
-  "Call multiple 'methods' on one 'self'.
+(defmacro doto (self : :* invocations)
+  "Configure an object.
+
+  Calls multiple 'methods' on one 'self'.
 
   Evaluates the given ``self``, then injects it as the first argument to
-  a sequence of invocations. Returns the result of the last one.
+  a sequence of invocations. Returns ``self``.
   "
   (let ($self `$#self)
     `((lambda (: ,$self ,self)
@@ -235,7 +237,8 @@ meditate on this.
                  `(,(operator..getitem invocation 0)
                    ,$self
                    ,@(operator..getitem invocation (slice 1 None))))
-               invocations)))))
+               invocations)
+        ,$self))))
 
 ;;; threading
 

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -96,7 +96,7 @@ class Compiler:
 
     def compile(self, forms: Iterable) -> str:
         """
-        Compile multiple forms, and execute them them if evaluate mode enabled.
+        Compile multiple forms, and execute them if evaluate mode enabled.
         """
         result: List[str] = []
         for form in forms:

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -73,8 +73,8 @@ Token = NewType("Token", Tuple[str, str, int])
 
 DROP = object()
 """
-The sentinel value returned by the discard macro ``_#``, which the 
-reader skips over when parsing. Reader macros can have read-time side 
+The sentinel value returned by the discard macro ``_#``, which the
+reader skips over when parsing. Reader macros can have read-time side
 effects with no Hissp output by returning this.
 """
 

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -24,6 +24,7 @@ from itertools import chain
 from keyword import iskeyword as _iskeyword
 from pathlib import Path, PurePath
 from pprint import pformat, pprint
+from threading import Lock
 from types import ModuleType
 from typing import Any, Iterable, Iterator, NewType, Optional, Tuple, Union
 
@@ -131,13 +132,14 @@ class _Unquote(tuple):
         return f"_Unquote{super().__repr__()}"
 
 
-def gensym_counter(count=[0]):
+def gensym_counter(_count=[0], _lock=Lock()):
     """
     Call to increment the gensym counter, and return the new count.
     Used by the gensym reader macro ``$#`` to ensure symbols are unique.
     """
-    count[0] += 1
-    return count[0]
+    with _lock:
+        _count[0] += 1
+        return _count[0]
 
 
 class Lissp:

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -52,13 +52,13 @@
       (.assertEqual self x 1)
       (.assertEqual self y 2)))
 
-  test_cascade
+  test_doto
   (lambda (self)
     (.assertEqual self
-                  (!#cascade []
-                           (.append 3)
-                           (.extend [1,2])
-                           (sorted))
+                  (!#doto []
+                    (.append 3)
+                    (.extend [1,2])
+                    (.sort))
                   [1,2,3]))
 
   test_if-else
@@ -102,7 +102,7 @@
   test_&&
   (lambda (self)
     (!#let (xs [])
-      (!#cascade xs
+      (!#doto xs
         (.append (!#&&))
         (.append (!#&& 0))
         (.append (!#&& 1))
@@ -123,7 +123,7 @@
   test_||
   (lambda (self)
     (!#let (xs [])
-      (!#cascade xs
+      (!#doto xs
         (.append (!#||))
         (.append (!#|| 0))
         (.append (!#|| 1))

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -204,7 +204,7 @@
   test_prelude
   (lambda (self)
     (!#let (ns {})
-      (exec (hissp.compiler..readerless '(hissp.basic.._macro_.prelude)) ns)
+      (!#prelude ns)
       (.assertEqual self
                     (set operator..__all__)
                     (.intersection (set operator..__all__) (.keys ns)))

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -136,6 +136,7 @@ class TestReader(TestCase):
             )],
         )
 
+
 EXPECTED = {
 # Numeric
 '''False True''': [False, True],
@@ -226,5 +227,3 @@ r'''\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \ ''':
      'xSPACE_'],
 r'''\b\u\i\l\t\i\n\s..\f\l\o\a\t#\i\n\f''': [math.inf],
 }
-
-


### PR DESCRIPTION
There are several more sections I could add to the macro tutorial, but this has been open for a while. It's time to sync up.

Also replaces cascade with doto. If you're not using the return value, simply subsitute the word. Closes #99.

Gives prelude an optional namespace argument.
Make gensym counter threadsafe.

Various typos and fixes.