### PR TITLE
More thorough tutorial, and kwarg improvement

### DIFF
--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -375,6 +375,8 @@ class Compiler:
 
     def _pair_arg(self, k, v):
         k = PAIR_WORDS.get(k, k + "=")
+        if '..' in k:
+            k = k.split('.')[-1]
         return k + self.form(v).replace("\n", "\n" + " " * len(k))
 
     @_trace


### PR DESCRIPTION
I've added some more exposition to confusing parts of the tutorial based on some more feedback from @konstell.

I've also tweaked the compiler to make kwargs easier to use in templates of calls. It took me a while to notice the problem that kwarg symbols in templates get qualified. It's annoying to have to interpolate all of these, especially when nesting templates. I was starting to regret the choice of not using control words for kwargs like Hy and Common Lisp do, but I do have really compelling reasons to use symbols here. Clojure doesn't have this problem. Anyway, the compiler is the right place to fix this, not the templates.