### PR TITLE
Reset abort state before exit

### DIFF
--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -109,6 +109,7 @@ class Compiler:
             result.extend(self.eval(form))
             if self.abort:
                 print("\n\n".join(result), file=sys.stderr)
+                self.abort = False  # To allow REPL debugging.
                 sys.exit(1)
         return "\n\n".join(result)
 


### PR DESCRIPTION
This allows `lissp -i` to drop into a working REPL even if the main script raised an exception, as `python -i` does.

Pretty sure this fixes #114.