### PR TITLE
Fully qualify en- group internals

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -965,9 +965,9 @@ Like this
    ...    'def entuple(*xs):return xs\n'
    ...    'def enlist(*xs):return[*xs]\n'
    ...    'def enset(*xs):return{*xs}\n'
-   ...    'def enfrost(*xs):return frozenset(xs)\n'
+   ...    "def enfrost(*xs):return __import__('builtins').frozenset(xs)\n"
    ...    'def endict(*kvs):return{k:i.__next__()for i in[kvs.__iter__()]for k in i}\n'
-   ...    "def enstr(*xs):return''.join(map(str,xs))\n"
+   ...    "def enstr(*xs):return''.join(''.__class__(x)for x in xs)\n"
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -1537,9 +1537,9 @@ Lissp Quick Start
    ...    'def entuple(*xs):return xs\n'
    ...    'def enlist(*xs):return[*xs]\n'
    ...    'def enset(*xs):return{*xs}\n'
-   ...    'def enfrost(*xs):return frozenset(xs)\n'
+   ...    "def enfrost(*xs):return __import__('builtins').frozenset(xs)\n"
    ...    'def endict(*kvs):return{k:i.__next__()for i in[kvs.__iter__()]for k in i}\n'
-   ...    "def enstr(*xs):return''.join(map(str,xs))\n"
+   ...    "def enstr(*xs):return''.join(''.__class__(x)for x in xs)\n"
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -230,9 +230,9 @@ And push it to the REPL as well:
    ...    'def entuple(*xs):return xs\n'
    ...    'def enlist(*xs):return[*xs]\n'
    ...    'def enset(*xs):return{*xs}\n'
-   ...    'def enfrost(*xs):return frozenset(xs)\n'
+   ...    "def enfrost(*xs):return __import__('builtins').frozenset(xs)\n"
    ...    'def endict(*kvs):return{k:i.__next__()for i in[kvs.__iter__()]for k in i}\n'
-   ...    "def enstr(*xs):return''.join(map(str,xs))\n"
+   ...    "def enstr(*xs):return''.join(''.__class__(x)for x in xs)\n"
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -388,9 +388,9 @@ from itertools import *;from operator import *
 def entuple(*xs):return xs
 def enlist(*xs):return[*xs]
 def enset(*xs):return{*xs}
-def enfrost(*xs):return frozenset(xs)
+def enfrost(*xs):return __import__('builtins').frozenset(xs)
 def endict(*kvs):return{k:i.__next__()for i in[kvs.__iter__()]for k in i}
-def enstr(*xs):return''.join(map(str,xs))
+def enstr(*xs):return''.join(''.__class__(x)for x in xs)
 def engarde(xs,f,*a,**kw):
  try:return f(*a,**kw)
  except xs as e:return e


### PR DESCRIPTION
I replaced `map` with a generator expression, `str` with `''.__class__` (`.__str__()` doesn't work on type objects), and `frozenset` with `__import__('builtins').frozenset`, which is still vulnerable to `__import__` shadowing, but so are most of the Hissp macros.

If these were defined in a module with its own separate globals dict, this level of defensiveness would be silly. But it's not imported from a module. It's code for an in-line macroexpansion, which means the internals should be fully qualified to prevent shadowing and late-binding later in the module from breaking them.