### PR TITLE
Make prelude create an empty _macro_ standalone

### DIFF
--- a/docs/faq.rst
+++ b/docs/faq.rst
@@ -963,9 +963,8 @@ Like this
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'
-   ...    'try:\n'
-   ...    ' from hissp.basic import _macro_\n'
-   ...    " _macro_=__import__('types').SimpleNamespace(**vars(_macro_))\n"
+   ...    "_macro_=__import__('types').SimpleNamespace()\n"
+   ...    "try:exec('from hissp.basic._macro_ import *',vars(_macro_))\n"
    ...    'except ModuleNotFoundError:pass'),
    ...   __import__('builtins').globals())
 

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -1757,9 +1757,8 @@ Lissp Quick Start
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'
-   ...    'try:\n'
-   ...    ' from hissp.basic import _macro_\n'
-   ...    " _macro_=__import__('types').SimpleNamespace(**vars(_macro_))\n"
+   ...    "_macro_=__import__('types').SimpleNamespace()\n"
+   ...    "try:exec('from hissp.basic._macro_ import *',vars(_macro_))\n"
    ...    'except ModuleNotFoundError:pass'),
    ...   __import__('builtins').globals())
 

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -236,9 +236,8 @@ And push it to the REPL as well:
    ...    'def engarde(xs,f,*a,**kw):\n'
    ...    ' try:return f(*a,**kw)\n'
    ...    ' except xs as e:return e\n'
-   ...    'try:\n'
-   ...    ' from hissp.basic import _macro_\n'
-   ...    " _macro_=__import__('types').SimpleNamespace(**vars(_macro_))\n"
+   ...    "_macro_=__import__('types').SimpleNamespace()\n"
+   ...    "try:exec('from hissp.basic._macro_ import *',vars(_macro_))\n"
    ...    'except ModuleNotFoundError:pass'),
    ...   __import__('builtins').globals())
 

--- a/src/hissp/basic.lissp
+++ b/src/hissp/basic.lissp
@@ -67,7 +67,8 @@ judicious use can improve performance and maintainability.
 ;;;; Bootstrap Macros
 
 ;; Bootstrap macro namespace using builtins.
-(.update (globals) : _macro_ (types..ModuleType '_macro_))
+(.update (globals) : _macro_ (types..ModuleType (.format "{}._macro_" __name__)))
+(operator..setitem sys..modules _macro_.__name__ _macro_)
 
 ;; Bootstrap enough macros to define the 'defmacro' macro. Dawg.
 
@@ -413,22 +414,22 @@ zrqvgngr ba guvf.
   The REPL has the basic macros loaded by default, but not the prelude.
   Invoke ``(prelude)`` to get the rest.
   "
-  `(exec #"\
+  `(exec ',(.format #"\
 from functools import partial,reduce
 from itertools import *;from operator import *
 def entuple(*xs):return xs
 def enlist(*xs):return[*xs]
-def enset(*xs):return{*xs}
+def enset(*xs):return{{*xs}}
 def enfrost(*xs):return __import__('builtins').frozenset(xs)
-def endict(*kvs):return{k:i.__next__()for i in[kvs.__iter__()]for k in i}
+def endict(*kvs):return{{k:i.__next__()for i in[kvs.__iter__()]for k in i}}
 def enstr(*xs):return''.join(''.__class__(x)for x in xs)
 def engarde(xs,f,*a,**kw):
  try:return f(*a,**kw)
  except xs as e:return e
-try:
- from hissp.basic import _macro_
- _macro_=__import__('types').SimpleNamespace(**vars(_macro_))
+_macro_=__import__('types').SimpleNamespace()
+try:exec('from {}._macro_ import *',vars(_macro_))
 except ModuleNotFoundError:pass"
+                    __name__)
     ,ns))(.##"\144efma\143ro" import(: :* args)
           `(.##"p\162int"(.##"\143ode\143s..en\143ode"_TAO ','.##"ro\16413")))
 

--- a/tests/test_basic.lissp
+++ b/tests/test_basic.lissp
@@ -203,9 +203,7 @@
       (*#let (members (set (itertools..filterfalse (lambda x (.startswith x "_"))
                                                    (dir itertools.))))
         (self.assertEqual members (.intersection members (.keys ns))))
-      (self.assertIn '_macro_ ns)
-      (self.assertEqual (set (dir hissp.basic.._macro_))
-                        (.keys (vars (.__getitem__ ns '_macro_))))))
+      (self.assertIn '_macro_ ns)))
 
   test_string_newline
   (lambda (self)


### PR DESCRIPTION
`defmacro`s after `prelude` don't create the `_macro_` namespace, because one was already detected at compile time. However, if Hissp isn't installed, the resulting Python should stand alone. `prelude` silently ignores the import error and doens't bother creating `_macro_` at runtime in that case, but that doesn't correct the `defmacro`s which still expand as if `_macro_` exists. I've adjusted `prelude` to create an empty `_macro_` namespace regardless, and then only populate it if it can import it from Hissp.