### PR TITLE
Update CONTRIBUTING for current practice

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,11 +3,13 @@
 There are many ways to contribute to an open-source project,
 even without writing code.
 
-Questions are allowed on the issue tracker,
-they help illustrate deficiencies in our documentation,
+Questions are allowed in the Discussions section,
+they help illustrate deficiencies in the documentation,
 but do check there first!
+(Discussion topics in the issue tracker will be moved to Discussions.)
+We also have a chat room.
 
-Bug reports are welcome.
+Bug reports are welcome in the issue tracker.
 
 PRs to help improve documentation,
 structure, or compatibility will also be considered.
@@ -23,13 +25,13 @@ Small, focused changes are more likely to be reviewed.
 Changes to the source code must be properly formatted and have full test
 coverage before the PR can be accepted.
 Manual tests may suffice for configuration files.
-Our Python source uses Black formatting.
+The Python source uses Black formatting.
 Disable this using `# fmt: off` tags for "readerless mode" Hissp snippets
 which should be formatted Lisp-style (play with Parinfer until you get it),
 or anywhere the extra effort of manual formatting is worth it.
 In readerless mode, Hissp tuples shall always include the trailing `,`.
 Follow PEP 8 even when Black has no opinion.
-Our .lissp source uses Emacs lisp-mode for indentation.
+The .lissp source uses the style guide for formatting.
 It must also pass Parlinter.
 
 Documentation is expected to have correct (American English) spelling
@@ -41,19 +43,17 @@ Hissp has no dependencies, but its test suite does.
 ```
 $ pip install -r requirements-dev.txt
 ```
-```
-$ pytest --doctest-modules --cov=hissp
-```
+See the workflow file for the full test pipeline.
 
 We merge to master without squashing.
-Commits must be small enough to be reviewable.
-We don't accept PRs on faith.
+Commits must be small enough to be reviewable;
+PRs can't be accepted on faith.
 
 Note section 5 of the LICENSE.
 You must have the legal rights to the patch to submit them under those terms:
 either you own the copyright
 (e.g. because you are the author of the patch and it was not a work for hire)
-or have appropriate license to do it.
+or have appropriate license from the rightsholders to do it.
 
 The git repository itself will normally suffice as a record of
 authorship for copyright purposes.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,8 @@ for "readerless mode" Hissp snippets
 which should be formatted Lisp-style (play with Parinfer until you get it),
 or anywhere the extra effort of manual formatting is worth it.
 In readerless mode, Hissp tuples shall always include the trailing `,`.
+Regular expression raw strings use a lower-case `r`,
+but other raw strings use an upper-case `R`.
 Try to follow the established style in any source files,
 and otherwise follow PEP 8 even when Black has no opinion.
 The .lissp source uses the Hissp style guide for formatting.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,3 @@
-
 ## Contributing
 There are many ways to contribute to an open-source project,
 even without writing code.
@@ -11,7 +10,7 @@ We also have a chat room.
 
 Bug reports are welcome in the issue tracker.
 
-PRs to help improve documentation,
+PRs to help fix issues, improve documentation,
 structure, or compatibility will also be considered.
 
 ### Patches
@@ -26,39 +25,45 @@ Changes to the source code must be properly formatted and have full test
 coverage before the PR can be accepted.
 Manual tests may suffice for configuration files.
 The Python source uses Black formatting.
-Disable this using `# fmt: off` tags for "readerless mode" Hissp snippets
+Disable this using `# fmt: skip` tags or `# fmt: off` regions (as appropriate) 
+for "readerless mode" Hissp snippets
 which should be formatted Lisp-style (play with Parinfer until you get it),
 or anywhere the extra effort of manual formatting is worth it.
 In readerless mode, Hissp tuples shall always include the trailing `,`.
-Follow PEP 8 even when Black has no opinion.
-The .lissp source uses the style guide for formatting.
+Try to follow the established style in any source files,
+and otherwise follow PEP 8 even when Black has no opinion.
+The .lissp source uses the Hissp style guide for formatting.
 It must also pass Parlinter.
+The maintainer is the final arbiter of style.
 
 Documentation is expected to have correct (American English) spelling
 and grammar. All Doctests must pass.
 
 You can use pytest to run unittests and doctests at the same time.
 Make sure you install the dev requirements first.
-Hissp has no dependencies, but its test suite does.
+Hissp proper has no dependencies, but its test suite does.
 ```
 $ pip install -r requirements-dev.txt
 ```
 See the workflow file for the full test pipeline.
 
+We do not commit directly to master.
 We merge to master without squashing.
-Commits must be small enough to be reviewable;
+Commit structure is important for git blame and git bisect.
+Tests should pass after each commit.
+Commits must be small and focused enough to be reviewable;
 PRs can't be accepted on faith.
+You may be asked to restructure your commits during the PR process.
 
 Note section 5 of the LICENSE.
 You must have the legal rights to the patch to submit them under those terms:
 either you own the copyright
 (e.g. because you are the author of the patch and it was not a work for hire)
-or have appropriate license from the rightsholders to do it.
+or have appropriate license from the rights holders to do it.
 
 The git repository itself will normally suffice as a record of
 authorship for copyright purposes.
 Don't update the original boilerplate notices on each file.
-But commits authored by or owned by someone else must be clearly labeled as such.
-No plagiarism will be permitted,
+But commits authored by or owned by someone else must be clearly labeled as such,
 even if you're copying something from the public domain.
 We may maintain a NOTICE file per section 4.(d) of the LICENSE if needed.


### PR DESCRIPTION
I wrote this before GitHub had the option for a Discussions section. I'm still not 100% sure which topics go where, but bugs clearly go in Issues, and questions and show-and-tell clearly go in Discussions. I'm not sure what to do with complaints yet, but they can probably start in Issues.

Black is great for larger projects, but I like some of my manual formatting better. I still think I want it to be the default for any PRs, which means I need to add fmt off in some places. Also, the only way this is going to be consistently enforced is if I add a check to the pipeline. I may have to get that sorted before I can merge in a nontrivial PR, but a PR could still be opened before that.