### PR TITLE
Sybil lissp

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -57,7 +57,7 @@ jobs:
     - name: Test install with pytest (including doctests)
       run: |
         python -c "import tests"  # Compiles hissp.basic on package import.
-        pytest -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
+        pytest -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
     - name: Codecov
       uses: codecov/codecov-action@v1.0.4
       with:

--- a/conftest.py
+++ b/conftest.py
@@ -35,6 +35,14 @@ class ParseLissp(DocTestParser):
             re.MULTILINE | re.VERBOSE,
         )
 
+    def __call__(self, document, *a, **kw):
+        assert type(document.text) is str
+        if document.path.endswith(".lissp"):
+            document.text = re.sub(
+                r"(?m)(^ *! *;)", lambda m: " " * len(m[1]), document.text
+            )
+        return super().__call__(document, *a, **kw)
+
     def lissp(self, source):
         lissp = LISSP.match(source)
         if not lissp:
@@ -82,5 +90,6 @@ class Globs(Container):
 
 
 pytest_collect_file = Sybil(
-    parsers=[ParseLissp(optionflags=ELLIPSIS)], filenames=Globs("*.md", "*.rst")
+    parsers=[ParseLissp(optionflags=ELLIPSIS)],
+    filenames=Globs("*.md", "*.rst", "*.lissp"),
 ).pytest()

--- a/docs/lissp_quickstart.rst
+++ b/docs/lissp_quickstart.rst
@@ -3692,20 +3692,20 @@ Lissp Quick Start
    >>> # hissp.._macro_.alias
    ... # hissp.macros.._macro_.defmacro
    ... # hissp.macros.._macro_.let
-   ... (lambda _QzNo7_fn=(lambda _QzNo34_prime,_QzNo34_reader=None,*_QzNo34_args:(
-   ...   "('Aliases hissp.._macro_ as MQzCOLON_#')",
+   ... (lambda _QzNo7_fn=(lambda _QzNo27_prime,_QzNo27_reader=None,*_QzNo27_args:(
+   ...   'Aliases ``hissp.._macro_`` as ``MQzCOLON_#``.',
    ...   # hissp.macros.._macro_.ifQz_else
    ...   (lambda test,*thenQz_else:
    ...     __import__('operator').getitem(
    ...       thenQz_else,
    ...       __import__('operator').not_(
    ...         test))())(
-   ...     _QzNo34_reader,
+   ...     _QzNo27_reader,
    ...     (lambda :
    ...       __import__('builtins').getattr(
    ...         __import__('hissp')._macro_,
    ...         ('{}{}').format(
-   ...           _QzNo34_reader,
+   ...           _QzNo27_reader,
    ...           # hissp.macros.._macro_.ifQz_else
    ...           (lambda test,*thenQz_else:
    ...             __import__('operator').getitem(
@@ -3717,12 +3717,16 @@ Lissp Quick Start
    ...               '_macro_'),
    ...             (lambda :'QzHASH_'),
    ...             (lambda :('')))))(
-   ...         _QzNo34_prime,
-   ...         *_QzNo34_args)),
+   ...         _QzNo27_prime,
+   ...         *_QzNo27_args)),
    ...     (lambda :
    ...       ('{}.{}').format(
    ...         'hissp.._macro_',
-   ...         _QzNo34_prime))))[-1]):(
+   ...         _QzNo27_prime))))[-1]):(
+   ...   __import__('builtins').setattr(
+   ...     _QzNo7_fn,
+   ...     '__doc__',
+   ...     'Aliases ``hissp.._macro_`` as ``MQzCOLON_#``.'),
    ...   __import__('builtins').setattr(
    ...     _QzNo7_fn,
    ...     '__qualname__',

--- a/src/hissp/__init__.py
+++ b/src/hissp/__init__.py
@@ -12,6 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+# :Abguvatarff nobir nofgenpgvba:  ohg vzcyrzragngvba vf / gur orfg anzr.:Grefrarff znl znxr bar gbb znal / trg hfrq~
+# gb gurz:  ryfr biresybj lbhe oenva.:Ab fhofgvghgr sbe haqrefgnaqvat:Pbqr;     gur yvnovyvgl:nf nffrg;~
+# gur   novyvgl.:Gur ovttrfg puhaxf / ner uneq gb fjnyybj:  nf fvzcyr nf cbffvoyr / ab zber.:Fbhepr jnf znqr / sbe gur~
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# uhzna:  bowrpg / gur znpuvar.:Ner lbh ynml rabhtu gb orne / gur fvaprerfg sbez / bs bgure jnlf bs orvat?:*univat*~
+# qrprag fgnaqneqf / vf zber vzcbegnag / guna rknpgyl jung gurl ner:Cresrpgvba / vf rkcrafvir:  zntvp / uvtuyl~
+# cevprq:  cnl sbe jura / vg'f Jbegu Vg:  n dhnegre vf nqivfrq:Ernqnovyvgl / vf znvayl / ynvq bhg ba gur cntr.:Tbysvat~
+# / znxrf tbbq cenpgvpr / orfg cenpgvpr vg orgenlf.:Pnfgyrf ohvyg / va gur nve / juvgure gurl qb orybat?:  Ryrtnapr /~
+# gura rkprcgvba:  Sbez / orsber qrgnvy:  jurapr haqre gurz,:Sbhaqngvbaf nccrne.:Znxr gur evtug jnl boivbhf,:zrqvgngr~
+# ba guvf.:  --Mn Mra bs Uvffc:~
 """It's Python with a `Lissp`.
 
 See the GitHub project for complete documentation and tests.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -152,6 +152,40 @@ judicious use can improve performance and maintainability.
                   ',name
                   ,$fn)))))
 
+(defmacro <<\# (single : :* lines)
+  (if-else lines
+    `',(.join (ast..literal_eval single)
+              (map (operator..attrgetter 'content) lines))
+    `',(getattr single 'content)))
+
+(setattr
+ _macro_.<<\# '__doc__
+ <<#
+ !;``<<#`` comment-string reader macro.
+ !;
+ !;Converts a line comment to a raw string.
+ !;
+ !;.. code-block:: REPL
+ !;
+ !;   #> <<#;Don't worry about the "quotes".
+ !;   >>> 'Don\'t worry about the "quotes".'
+ !;   'Don\'t worry about the "quotes".'
+ !;
+ !;Or joins extra comments with a string object,
+ !;such as ``#"\n"``.
+ !;
+ !;.. code-block:: REPL
+ !;
+ !;   #> <<#
+ !;   #..!;C:\bin
+ !;   #..!;C:\Users\ME\Documents
+ !;   #..!;C:\Users\ME\Pictures
+ !;   #..";"
+ !;   >>> 'C:\\bin;C:\\Users\\ME\\Documents;C:\\Users\\ME\\Pictures'
+ !;   'C:\\bin;C:\\Users\\ME\\Documents;C:\\Users\\ME\\Pictures'
+ !;
+ #"\n")
+
 (defmacro define (name value)
   "Assigns a global the value in the current module."
   `(.update (globals)
@@ -223,24 +257,26 @@ judicious use can improve performance and maintainability.
   `(lambda ,'XYZW ,e))
 
 (defmacro alias (alias module)
-  #"Defines a reader macro abbreviation of a qualifier. For example,
-
-  .. code-block:: Lissp
-
-     (hissp.macros.._macro_.alias M/ hissp.macros.._macro_)
-     ;; Now the same as (hissp.macros.._macro_.alias op sub.).
-     (M/#alias op operator.)
-     ;; Use an extra to name a reader macro.
-     M/#!b\"byte string\"
-     (op#sub 2 3)
-     #> op#!pow !3 2
-     >>> (8)
-     8
-
-  " ; TODO: doctest examples.
+  <<#
+  !;Defines a reader macro abbreviation of a qualifier. For example,
+  !;
+  !;.. code-block:: Lissp
+  !;
+  !;   (hissp.macros.._macro_.alias M/ hissp.macros.._macro_)
+  !;   ;; Now the same as (hissp.macros.._macro_.alias op sub.).
+  !;   (M/#alias op operator.)
+  !;   ;; Use an extra to name a reader macro.
+  !;   M/#!b"byte string"
+  !;   (op#sub 2 3)
+  !;   #> op#!pow !3 2
+  !;   >>> (8)
+  !;   8
+  !;
+  !;
+  #"\n" ; TODO: doctest examples.
   `(defmacro ,(.format "{}{}" alias '#)
              ($#prime : $#reader None :* $#args)
-     ',(.format "('Aliases {} as {}#')" module alias) ; TODO: docstrings not compiling in?
+     ',(.format "Aliases ``{}`` as ``{}#``." module alias)
      (if-else $#reader
        ((getattr ,module (.format "{}{}"
                                   $#reader
@@ -489,65 +525,36 @@ judicious use can improve performance and maintainability.
       (->> (.format "b'{}'"))
       (ast..literal_eval)))
 
-(defmacro <<\# (single : :* lines)
-  #"``<<#`` comment-string reader macro.
-
-  Converts a line comment to a raw string.
-
-  .. code-block:: REPL
-
-     #> <<#;Don't worry about the \"quotes\".
-     >>> 'Don\'t worry about the \"quotes\".'
-     'Don\'t worry about the \"quotes\".'
-
-  Or joins extra comments with a string object,
-  such as ``#\"\\n\"``.
-
-  .. code-block:: REPL
-
-     #> <<#
-     #..!;C:\\bin
-     #..!;C:\\Users\\ME\\Documents
-     #..!;C:\\Users\\ME\\Pictures
-     #..\";\"
-     >>> 'C:\\\\bin;C:\\\\Users\\\\ME\\\\Documents;C:\\\\Users\\\\ME\\\\Pictures'
-     'C:\\\\bin;C:\\\\Users\\\\ME\\\\Documents;C:\\\\Users\\\\ME\\\\Pictures'
-
-  "
-  (if-else lines
-    `',(.join (ast..literal_eval single)
-              (map (op#attrgetter 'content) lines))
-    `',(getattr single 'content)))
-
 (defmacro en\# (f)
-  "``en#`` reader macro.
-  Wrap a function of one iterable as a function of its elements.
-
-  .. code-block:: REPL
-
-     #> (en#list 1 2 3)
-     >>> (lambda *_xs_QzNo31_:
-     ...   list(
-     ...     _xs_QzNo31_))(
-     ...   (1),
-     ...   (2),
-     ...   (3))
-     [1, 2, 3]
-
-     #> (en#.extend _ 4 5 6) ; Methods too.
-     >>> (lambda _self_QzNo31_,*_xs_QzNo31_:
-     ...   _self_QzNo31_.extend(
-     ...     _xs_QzNo31_))(
-     ...   _,
-     ...   (4),
-     ...   (5),
-     ...   (6))
-
-     #> _
-     >>> _
-     [1, 2, 3, 4, 5, 6]
-
-  " ; TODO: doctest examples
+  <<#
+  !;``en#`` reader macro.
+  !;Wrap a function of one iterable as a function of its elements.
+  !;
+  !;.. code-block:: REPL
+  !;
+  !;   #> (en#list 1 2 3)
+  !;   >>> (lambda *_xs_QzNo31_:
+  !;   ...   list(
+  !;   ...     _xs_QzNo31_))(
+  !;   ...   (1),
+  !;   ...   (2),
+  !;   ...   (3))
+  !;   [1, 2, 3]
+  !;
+  !;   #> (en#.extend _ 4 5 6) ; Methods too.
+  !;   >>> (lambda _self_QzNo31_,*_xs_QzNo31_:
+  !;   ...   _self_QzNo31_.extend(
+  !;   ...     _xs_QzNo31_))(
+  !;   ...   _,
+  !;   ...   (4),
+  !;   ...   (5),
+  !;   ...   (6))
+  !;
+  !;   #> _
+  !;   >>> _
+  !;   [1, 2, 3, 4, 5, 6]
+  !;
+  #"\n" ; TODO: doctest examples
   (if-else (&& (op#is_ str (type f))
                (.startswith f "."))
     `(lambda ($#self : :* $#xs)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -158,6 +158,18 @@ judicious use can improve performance and maintainability.
               (map (operator..attrgetter 'content) lines))
     `',(getattr single 'content)))
 
+_#<<#
+!;Hidden doctest adds bundled macros for REPL-consistent behavior.
+!;#> (operator..setitem (globals) '_macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
+!;>>> __import__('operator').setitem(
+!;...   globals(),
+!;...   '_macro_',
+!;...   __import__('types').SimpleNamespace(
+!;...     **vars(
+!;...         __import__('hissp')._macro_)))
+!;
+#"\n"
+
 (setattr
  _macro_.<<\# '__doc__
  <<#
@@ -272,8 +284,7 @@ judicious use can improve performance and maintainability.
   !;   >>> (8)
   !;   8
   !;
-  !;
-  #"\n" ; TODO: doctest examples.
+  #"\n"
   `(defmacro ,(.format "{}{}" alias '#)
              ($#prime : $#reader None :* $#args)
      ',(.format "Aliases ``{}`` as ``{}#``." module alias)
@@ -388,6 +399,10 @@ judicious use can improve performance and maintainability.
     expr))
 
 ;; TODO: implement other arrange macros?
+
+(define _TAO
+  (lambda s (-> (.join " " (re..findall "(?m)^# (.*)~$" (s hissp.)))
+                (.replace ":" #"\n"))))
 
 ;;; control flow
 
@@ -533,18 +548,18 @@ judicious use can improve performance and maintainability.
   !;.. code-block:: REPL
   !;
   !;   #> (en#list 1 2 3)
-  !;   >>> (lambda *_xs_QzNo31_:
+  !;   >>> (lambda *_QzNo53_xs:
   !;   ...   list(
-  !;   ...     _xs_QzNo31_))(
+  !;   ...     _QzNo53_xs))(
   !;   ...   (1),
   !;   ...   (2),
   !;   ...   (3))
   !;   [1, 2, 3]
   !;
   !;   #> (en#.extend _ 4 5 6) ; Methods too.
-  !;   >>> (lambda _self_QzNo31_,*_xs_QzNo31_:
-  !;   ...   _self_QzNo31_.extend(
-  !;   ...     _xs_QzNo31_))(
+  !;   >>> (lambda _QzNo52_self,*_QzNo52_xs:
+  !;   ...   _QzNo52_self.extend(
+  !;   ...     _QzNo52_xs))(
   !;   ...   _,
   !;   ...   (4),
   !;   ...   (5),
@@ -554,7 +569,7 @@ judicious use can improve performance and maintainability.
   !;   >>> _
   !;   [1, 2, 3, 4, 5, 6]
   !;
-  #"\n" ; TODO: doctest examples
+  #"\n"
   (if-else (&& (op#is_ str (type f))
                (.startswith f "."))
     `(lambda ($#self : :* $#xs)
@@ -653,7 +668,9 @@ _macro_=__import__('types').SimpleNamespace()
 try:exec('from {}._macro_ import *',vars(_macro_))
 except ModuleNotFoundError:pass"
                     __name__)
-    ,ns))(.##"\144efma\143ro"import(: :* _)(.##"\144efine" _TAO .#"b'''Gapoqh/:as%)1%dp^V#lc5p@0#Yb`;?p]BsZobbeC!>#$,\\bTIe+5StU/J&1NU?2TER20!9iI3YM2/_M^9n[sS*&dfL:*/h99`RW@geH#\\u-<s#-!RpcZ4%jV,Z\\JB&<'l$KWP_ElKHn8=64#>/_^uaYR[)X>mX[3QHN@4g0Qo_O=6f3E'476eg=JcFM;j4BaR:*baA>p@:KB(lkOWB[jIP#)QN[4nL_]&I1LPX4(U8a0;FBj1n)3E9WJLKd0Co'l)7DfN(YJ<<oVo.=k)Di;*O@8\"g;0=`;%`TJ[-.aJ)'DI`p@RQ\"D)20_.E#*Cs)h^H5$0lP-Gl+C'r%<RWA80V[Qc?p58%Ob.1l[G;sus5)Q7hQXL50-bk</e\"*a/(e>kc*^df^Z+0>nci1U:7&c@g?g5;qZckm]7%qh[ma3F9u(9$8OnGd:'$2Ed8<$c$Tp>mQQSGl]rUc5blW<-VBGh?\\MV)k4nbA^G5#:p+*JVHiH2GLAG)0AB7OA>/3H5#:H>\"4&cZ^:.SVpM+L&[%:%LPrs7b4Y^tA)Jj;tk?Ll>cmB]ShiQITN[\"RUearnc.cfb>b/(hM^VCH(9\"Dkel(/U4k\\1!&%4p!Qqe_T!Z(I5^t!hn#_E?,%b[^+AdIjM'>j0F.hC2Y.OpZ>!Y2Xdd9[mZh&!/)V)sh7YMU!!3T/XL0\\K+1G-6(B'''")`(.##"p\162int"(.##".de\143ode"(.##"\143ode\143s..de\143ode"(.##"b\141se64..a85de\143ode"_TAO)#"z\151p"))))
+    ,ns))(.##"\144efma\143ro" import(: :* args)
+          `(.##"p\162int"(.##"\143ode\143s..en\143ode"
+                          (_TAO .##"in\163pe\143\164..ge\164\163our\143e")','.##"ro\16413")))
 
 ;;; advanced
 

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -140,7 +140,7 @@ judicious use can improve performance and maintainability.
     (let (fn `(lambda ,parameters ,docstring ,@body)
           ns (unless (operator..contains (.get hissp.compiler..NS) '_macro_)
                `((.update (globals) : _macro_ (types..ModuleType ','_macro_))))
-          dc (when (hissp.reader..is_string docstring)
+          dc (when (hissp.reader..is_hissp_string docstring)
                `((setattr ,$fn ','__doc__ ,docstring)))
           qn `(setattr ,$fn ','__qualname__ (.join "." '(,'_macro_ ,name))))
       `(let (,$fn ,fn)

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -301,7 +301,7 @@ class Lissp:
     def template(self, form):
         """Process form as template."""
         case = type(form)
-        if is_string(form):
+        if is_string_literal(form):
             return "quote", form
         if case is tuple and form:
             return (ENTUPLE, ":", *chain(*self._template(form)),)  # fmt: skip
@@ -416,7 +416,7 @@ class Lissp:
             )
 
 
-def is_string(form):
+def is_string_literal(form):
     """
     Determines if form could have been read from a Lissp string literal.
 
@@ -430,6 +430,26 @@ def is_string(form):
             type(form) is str
             and form.startswith("(")
             and type(ast.literal_eval(form)) is str
+        )
+    except:
+        return False
+
+
+def is_string(form):
+    """A less strict variant of `is_string_literal`.
+
+    Also allows "readerless mode"-style strings: ('quote', 'foo',)
+    and any string literal in a Hissp-level str: '"foo"'.
+
+    Macros often produce strings in one of these forms, via ``'`` or
+    `repr` on a string object.
+    """
+    try:
+        return (type(form) is str and type(ast.literal_eval(form)) is str) or (
+            type(form) is tuple
+            and len(form) == 2
+            and form[0] == "quote"
+            and type(form[1]) is str
         )
     except:
         return False

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -16,7 +16,7 @@ import ast
 import builtins
 import re
 from collections import namedtuple
-from contextlib import contextmanager, nullcontext
+from contextlib import contextmanager, nullcontext, suppress
 from functools import reduce
 from importlib import import_module, resources
 from itertools import chain, takewhile
@@ -301,7 +301,7 @@ class Lissp:
     def template(self, form):
         """Process form as template."""
         case = type(form)
-        if is_string_literal(form):
+        if is_lissp_string(form):
             return "quote", form
         if case is tuple and form:
             return (ENTUPLE, ":", *chain(*self._template(form)),)  # fmt: skip
@@ -416,7 +416,25 @@ class Lissp:
             )
 
 
-def is_string_literal(form):
+def is_hissp_string(form) -> bool:
+    """Determines if form would directly represent a string in Hissp.
+
+    Allows "readerless mode"-style strings: ('quote', 'foo',)
+    and any string literal in a Hissp-level str: '"foo"'
+    (including the "('foo')" form produced by the Lissp reader).
+
+    Macros often produce strings in one of these forms, via ``'`` or
+    `repr` on a string object.
+    """
+    return (
+        type(form) is tuple
+        and len(form) == 2
+        and form[0] == "quote"
+        and type(form[1]) is str
+    ) or bool(is_string_literal(form))
+
+
+def is_lissp_string(form) -> bool:
     """
     Determines if form could have been read from a Lissp string literal.
 
@@ -425,34 +443,16 @@ def is_string_literal(form):
     injections, read in as strings. Macros may need to distinguish these
     cases.
     """
-    try:
-        return (
-            type(form) is str
-            and form.startswith("(")
-            and type(ast.literal_eval(form)) is str
-        )
-    except:
-        return False
+    return type(form) is str and form.startswith("(") and bool(is_string_literal(form))
 
 
-def is_string(form):
-    """A less strict variant of `is_string_literal`.
+def is_string_literal(form) -> Optional[bool]:
+    """Determines if `ast.literal_eval` on form produces a string.
 
-    Also allows "readerless mode"-style strings: ('quote', 'foo',)
-    and any string literal in a Hissp-level str: '"foo"'.
-
-    Macros often produce strings in one of these forms, via ``'`` or
-    `repr` on a string object.
+    False if it produces something else or None if it raises Exception.
     """
-    try:
-        return (type(form) is str and type(ast.literal_eval(form)) is str) or (
-            type(form) is tuple
-            and len(form) == 2
-            and form[0] == "quote"
-            and type(form[1]) is str
-        )
-    except:
-        return False
+    with suppress(Exception):
+        return type(ast.literal_eval(form)) is str
 
 
 def _parse_extras(extras):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -185,7 +185,7 @@ class TestReader(TestCase):
         )  # fmt: skip
 
     def test_is_string_code(self):
-        self.assertFalse(reader.is_string("(1+1)"))
+        self.assertFalse(reader.is_string_literal("(1+1)"))
 
 
 EXPECTED = {

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -185,7 +185,7 @@ class TestReader(TestCase):
         )  # fmt: skip
 
     def test_is_string_code(self):
-        self.assertFalse(reader.is_string_literal("(1+1)"))
+        self.assertFalse(reader.is_lissp_string("(1+1)"))
 
 
 EXPECTED = {


### PR DESCRIPTION
Fixes an issue with docstrings not appearing in defmacro forms created by macros and enables Sybil tests in .lissp files.