### PR TITLE
Doc improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,7 +66,6 @@ instance/
 # Sphinx documentation
 docs/_build/
 docs/_static/
-docs/_templates/
 
 # PyBuilder
 target/

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ python -m pip install -U hissp
 ```
 Or install the bleeding-edge version directly from GitHub with
 ```
-python -m pip install -U git+https://github.com/gilch/hissp.git
+python -m pip install -U git+https://github.com/gilch/hissp
 ```
 
 # Show Me Code!

--- a/README.md
+++ b/README.md
@@ -252,11 +252,11 @@ Requires [Bottle.](https://bottlepy.org/docs/dev/)
       (.join #"\n" (map hissp.compiler..readerless forms))))
 
 (define temperature
-  ((bottle..route "/")
+  ((bottle..route "/") ; https://bottlepy.org
    &#(enjoin
       (let (s (tag "script src='https://cdn.jsdelivr.net/npm/brython@3/brython{}.js'"))
         (enjoin (.format s ".min") (.format s "_stdlib")))
-      (tag "body onload='brython()'"
+      (tag "body onload='brython()'" ; Browser Python: https://brython.info
        (script
          (define getE X#(.getElementById browser..document X))
          (define getf@v X#(float (@#value (getE X))))

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ however, the quote and lambda forms are the two special cases built into the com
 (More can be added via the macro mechanism.)
 
 Strings also have a few special cases:
-* control words, which start with `:` (and may have special interpretations);
+* control words, which start with `:` (and may have various special interpretations);
 * method calls, which start with `.`, and must be the first element in a tuple representing a call;
 * and module handles, which end with `.` (and do imports).
 ```python
@@ -124,13 +124,13 @@ Strings also have a few special cases:
 ...   ('quote','Hello,'),),
 ...  ('print',
 ...   ':',  # Control word: Remaining arguments are paired with a target.
-...   ':*',  # Target: Special string: Control word for unpacking.
+...   ':*',  # Target: Control word for unpacking.
 ...   ('.upper','name',),  # Method calls start with a dot.
 ...   'sep',  # Target: Keyword argument.
 ...   ':',  # Control words compile to strings, not raw.
 ...   'file', # Target: Keyword argument.
-...   # Special string: module handles like `sys.` end in a dot.
-...   'sys..stdout',),)
+...   # Module handles like `sys.` end in a dot.
+...   'sys..stdout',),)  # print already defaults to stdout though.
 ... )
 ...
 >>> print(readerless(adv_hissp_code))

--- a/README.md
+++ b/README.md
@@ -101,13 +101,12 @@ tuples represent calls
 and strings represent raw Python code in Hissp.
 (Take everything else literally.)
 
-### Special Cases
+### Special Forms
 Like Python, argument expressions are evaluated before being passed to the function,
-however, the quote and lambda forms are the two special cases built into the compiler that break this rule.
-(More can be added via the macro mechanism.)
+however, the quote and lambda forms are special cases in the compiler and break this rule.
 
 Strings also have a few special cases:
-* control words, which start with `:` (and may have various special interpretations);
+* control words, which start with `:` (and may have various special interpretations in certain contexts);
 * method calls, which start with `.`, and must be the first element in a tuple representing a call;
 * and module handles, which end with `.` (and do imports).
 ```python
@@ -127,8 +126,8 @@ Strings also have a few special cases:
 ...   ':*',  # Target: Control word for unpacking.
 ...   ('.upper','name',),  # Method calls start with a dot.
 ...   'sep',  # Target: Keyword argument.
-...   ':',  # Control words compile to strings, not raw.
-...   'file', # Target: Keyword argument.
+...   ':',  # Control words compile to strings, not raw Python.
+...   'file',  # Target: Keyword argument.
 ...   # Module handles like `sys.` end in a dot.
 ...   'sys..stdout',),)  # print already defaults to stdout though.
 ... )
@@ -306,7 +305,7 @@ class: TestOr: TestCase
 The same Hissp macros work in readerless mode, Lissp, and Hebigo, and can be written in any of these.
 Given Hebigo's macros, the class above could be written in the equivalent way in Lissp:
 
-```Lisp
+```Racket
 (class_ (TestOr TestCase)
   (def_ (.test_null self)
     (self.assertEqual () (or_)))

--- a/README.md
+++ b/README.md
@@ -27,9 +27,12 @@ Python—Syntactic macro metaprogramming with full access to the Python ecosyste
 **Table of Contents**
 
 - [Installation](#installation)
-- [Show Me Code!](#show-me-code)
-    - [Readerless Mode](#readerless-mode)
-    - [Lissp](#lissp)
+- [Examples!](#examples)
+    - [Quick Start: Readerless Mode](#quick-start-readerless-mode)
+        - [Special Cases](#special-cases)
+        - [Macros](#macros)
+    - [The Lissp Reader](#the-lissp-reader)
+        - [A Small Lissp Example](#a-small-lissp-example)
     - [Hebigo](#hebigo)
 - [Features and Design](#features-and-design)
     - [Radical Extensibility](#radical-extensibility)
@@ -50,17 +53,22 @@ Hissp requires Python 3.8+.
 
 Install the latest PyPI release with
 ```
-python -m pip install -U hissp
+python -m pip install --upgrade hissp
 ```
 Or install the bleeding-edge version directly from GitHub with
 ```
-python -m pip install -U git+https://github.com/gilch/hissp
+python -m pip install --upgrade git+https://github.com/gilch/hissp
+```
+Confirm install with
+```
+python -m hissp --help
 ```
 
-# Show Me Code!
+# Examples!
 
-## Readerless Mode
-Hissp is a *metaprogramming* language composed of Python data structured into trees of tuples,
+## Quick Start: Readerless Mode
+Hissp is a *metaprogramming* intermediate language composed of simple Python data structures,
+easily generated programmatically,
 ```python
 >>> hissp_code = (
 ... ('lambda',('name',),
@@ -70,7 +78,7 @@ Hissp is a *metaprogramming* language composed of Python data structured into tr
 ```
 which are compiled to Python code,
 ```python
->>> from hissp.compiler import readerless
+>>> from hissp import readerless
 >>> python_code = readerless(hissp_code)
 >>> print(python_code)
 (lambda name:
@@ -81,15 +89,73 @@ which are compiled to Python code,
 ```
 and evaluated by Python.
 ```python
->>> eval(python_code)('World')
+>>> greeter = eval(python_code)
+>>> greeter('World')
 Hello World
+>>> greeter('Bob')
+Hello Bob
+
+```
+To a first approximation,
+tuples represent calls
+and strings represent raw Python code in Hissp.
+(Take everything else literally.)
+
+### Special Cases
+Like Python, argument expressions are evaluated before being passed to the function,
+however, the quote and lambda forms are the two special cases built into the compiler that break this rule.
+(More can be added via the macro mechanism.)
+
+Strings also have a few special cases:
+* control words, which start with `:` (and may have special interpretations);
+* method calls, which start with `.`, and must be the first element in a tuple representing a call;
+* and module handles, which end with `.` (and do imports).
+```python
+>>> adv_hissp_code = (
+... ('lambda',  # Anonymous function special form.
+...  # Parameters.
+...  (':',  # Control word: remaining parameters are paired with a target.
+...   'name',  # Target: Raw Python: Parameter identifier.
+...   # Default value for name.
+...   ('quote',  # Quote special form: string, not identifier. 
+...    'world'),),
+...  # Body.
+...  ('print',  # Function call form, using the identifier for the builtin.
+...   ('quote','Hello,'),),
+...  ('print',
+...   ':',  # Control word: Remaining arguments are paired with a target.
+...   ':*',  # Target: Special string: Control word for unpacking.
+...   ('.upper','name',),  # Method calls start with a dot.
+...   'sep',  # Target: Keyword argument.
+...   ':',  # Control words compile to strings, not raw.
+...   'file', # Target: Keyword argument.
+...   # Special string: module handles like `sys.` end in a dot.
+...   'sys..stdout',),)
+... )
+...
+>>> print(readerless(adv_hissp_code))
+(lambda name='world':(
+  print(
+    'Hello,'),
+  print(
+    *name.upper(),
+    sep=':',
+    file=__import__('sys').stdout))[-1])
+>>> greetier = eval(readerless(adv_hissp_code))
+>>> greetier()
+Hello,
+W:O:R:L:D
+>>> greetier('alice')
+Hello,
+A:L:I:C:E
 
 ```
 
-## Lissp
+## The Lissp Reader
 
 The Hissp data-structure language can be written directly in Python using the "readerless mode" demonstrated above,
-or it can be read in from a lightweight textual language called *Lissp* that represents the Hissp.
+or it can be read in from a lightweight textual language called *Lissp* that represents the Hissp
+a little more neatly.
 ```python
 >>> lissp_code = """
 ... (lambda (name)
@@ -97,7 +163,7 @@ or it can be read in from a lightweight textual language called *Lissp* that rep
 ... """
 
 ```
-As you can see, this results in exactly the same Hissp code as the previous example.
+As you can see, this results in exactly the same Hissp code as our earlier example.
 ```python
 >>> from hissp.reader import Lissp
 >>> next(Lissp().reads(lissp_code))
@@ -113,11 +179,12 @@ which compiles Hissp (read from Lissp) to Python and passes that to the Python R
 Lissp can also be read from ``.lissp`` files,
 which compile to Python modules.
 
-Here's a small example Lissp web app for converting between Celsius and Fahrenheit,
+### A Small Lissp Example
+This is a Lissp web app for converting between Celsius and Fahrenheit,
 which demonstrates a number of language features.
 Run as the main script or enter it into the Lissp REPL.
 Requires [Bottle.](https://bottlepy.org/docs/dev/)
-```Lisp
+```Racket
 (hissp.._macro_.prelude)
 
 (define enjoin en#X#(.join "" (map str X)))

--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Requires [Bottle.](https://bottlepy.org/docs/dev/)
 (bottle..run : host "localhost"  port 8080  debug True)
 ```
 You should be able to understand this much after completing the
-[quick start](https://hissp.readthedocs.io/).
+[Lissp Whirlwind Tour](https://hissp.readthedocs.io/).
 
 ## Hebigo
 
@@ -267,7 +267,7 @@ In [1]: pprint..pp:quote:class: TestOr: TestCase
    ('hebi.basic.._macro_.or_', 'x', 'y', 'z'))))
 ```
 
-Want more examples? See the [Hissp documentation](https://hissp.readthedocs.io/) for the quickstart and tutorials.
+Want more examples? See the [Hissp documentation](https://hissp.readthedocs.io/).
 
 # Features and Design
 

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,0 +1,11 @@
+{% extends '!base.html' %}
+
+{% block extrahead %}
+<script>
+    {{ super() }}
+     ((window.gitter = {}).chat = {}).options = {
+       room: 'hissp-lang/community'
+     };
+   </script>
+<script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+{% endblock %}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -35,6 +35,6 @@ or start with the easier, but less-comprehensive tutorial.
 
 .. toctree::
 
-   GitHub Repository <https://github.com/gilch/hissp>
+   ⭐ on GitHub <https://github.com/gilch/hissp>
 
 * :ref:`genindex`

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ It's Python with a *Lissp.*
 .. image:: hissp.svg
 
 Welcome to Hissp's documentation!
-Jump in and try the quick start first if you're feeling confident,
+Jump in and try the Lissp Whirlwind Tour first if you're feeling confident,
 or start with the easier, but less-comprehensive tutorial.
 
 .. TODO: add REPL via Brython or Pyodide?
@@ -20,7 +20,7 @@ or start with the easier, but less-comprehensive tutorial.
    :maxdepth: 2
    :caption: Contents:
 
-   lissp_quickstart
+   lissp_whirlwind_tour
    tutorial
    style_guide
    macro_tutorial

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,7 +11,7 @@ It's Python with a *Lissp.*
 .. image:: hissp.svg
 
 Welcome to Hissp's documentation!
-Jump in and try the Lissp Whirlwind Tour first if you're feeling confident,
+Jump in and try the *Lissp Whirlwind Tour* first if you're feeling confident,
 or start with the easier, but less-comprehensive tutorial.
 
 .. TODO: add REPL via Brython or Pyodide?

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -50,7 +50,7 @@ Lissp Whirlwind Tour
 
    ;; These docs are for the latest development version of Hissp.
    ;; Install the latest Hissp version with
-   ;; $ pip install git+https://github.com/gilch/hissp.git
+   ;; $ pip install git+https://github.com/gilch/hissp
    ;; Start the REPL with
    ;; $ lissp
    ;; You can quit with EOF or (exit).

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -12,16 +12,16 @@
 
 .. TODO: Interactive via web repl?
 
-Lissp Quick Start
-=================
+Lissp Whirlwind Tour
+====================
 
 .. raw:: html
 
-   (<a href="_sources/lissp_quickstart.rst.txt">Outputs</a> hidden for brevity.)
+   (<a href="_sources/lissp_whirlwind_tour.rst.txt">Outputs</a> hidden for brevity.)
 
 .. Lissp::
 
-   ;;;; 1 Lissp Quick Start
+   ;;;; 1 Lissp Whirlwind Tour
 
    "Lissp is a lightweight text language representing the Hissp
    intermediate language. The Lissp reader parses the Lissp language's

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -39,11 +39,12 @@ Lissp Whirlwind Tour
    Python and evaluate it. Try variations that occur to you.
 
    Familiarity with another Lisp dialect is not assumed, but helpful. If
-   you get confused or stuck, read the easier Hissp tutorial.
+   you get confused or stuck, the Hissp tutorial is easier.
 
    Some examples depend on state set by previous examples to work.
    Prerequisites for examples not in the same section are marked with
-   '/!\'. Don't skip these! Re-enter them if you start a new session.
+   '/!\'. Don't skip these! If you resume with a new REPL session,
+   re-enter them, but only up to your current section.
    "
 
    ;;;; 2 Installation

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -96,7 +96,7 @@ a subset of Python in a new skin.
 This one is about using that knowledge to reprogram the skin itself.
 
 If you don't know the basics from the `previous tutorial <tutorial>`,
-go back and read that now, or at least read the `quick start <lissp_quickstart>`.
+go back and read that now, or at least read the `Lissp Whirlwind Tour <lissp_whirlwind_tour>`.
 
 In the previous tutorial we mostly used the REPL,
 but it can become tedious to type long forms into the REPL,
@@ -1506,7 +1506,7 @@ Read the definition carefully.
 You can experiment with macros you don't recognize in the REPL.
 All the bundled macros,
 including the `|| <QzBAR_QzBAR_>`
-and `when` were covered in the `quick start <lissp_quickstart>`.
+and `when` were covered in the `Lissp Whirlwind Tour <lissp_whirlwind_tour>`.
 We're using them to coalesce Python's awkward regex matches,
 which can return ``None``, into a ``0``,
 unless it's a string with a match.

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1607,7 +1607,7 @@ like calls. ``:*`` and ``:**`` unpacking also work here.
    >>> (13)
    13
 
-See the `quick start <lissp_quickstart>` for more examples.
+See the `Lissp Whirlwind Tour <lissp_whirlwind_tour>` for more examples.
 
 Macros
 ======

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -48,7 +48,8 @@ In Hissp, you write in this parsed form far more directly:
 
 Some familiarity with Python is assumed for this tutorial.
 If you get confused or stuck,
-see the `discussions page. <https://github.com/gilch/hissp/discussions>`_
+see the `discussions page <https://github.com/gilch/hissp/discussions>`_
+or find the chat.
 
 Installation
 ============

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -57,7 +57,7 @@ Hissp requires Python 3.8+ and has no other dependencies.
 
 Install the Hissp version matching this document with::
 
-   $ pip install git+https://github.com/gilch/hissp.git
+   $ pip install git+https://github.com/gilch/hissp
 
 These docs are for the latest development version of Hissp.
 Most examples are tested automatically,


### PR DESCRIPTION
Added an abridged readerless quick start to the readme. To avoid future confusion, the old quickstart is now called the whirlwind tour.

Added a Gitter sidecar in the docs, to make the chat even easier to find.

Also adjusted some wording in various areas.