### PR TITLE
Fix sidecar z-index

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -6,6 +6,11 @@
      ((window.gitter = {}).chat = {}).options = {
        room: 'hissp-lang/community'
      };
-   </script>
+</script>
 <script src="https://sidecar.gitter.im/dist/sidecar.v1.js" async defer></script>
+<style type="text/css">
+.gitter-chat-embed {
+  z-index: 401
+}
+</style>
 {% endblock %}


### PR DESCRIPTION
The rst versions injected by readthedocs was rendering on top of the chat, which can hide text.