### PR TITLE
[# macro and doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,22 +250,21 @@ Requires [Bottle.](https://bottlepy.org/docs/dev/)
   `',(tag "script type='text/python'" #"\n"
       (.join #"\n" (map hissp.compiler..readerless forms))))
 
-(define temperature
-  ((bottle..route "/") ; https://bottlepy.org
-   &#(enjoin
-      (let (s (tag "script src='https://cdn.jsdelivr.net/npm/brython@3/brython{}.js'"))
-        (enjoin (.format s ".min") (.format s "_stdlib")))
-      (tag "body onload='brython()'" ; Browser Python: https://brython.info
-       (script
-         (define getE X#(.getElementById browser..document X))
-         (define getf@v X#(float (@#value (getE X))))
-         (define set@v XY#(setattr (getE Y) 'value X))
-         (attach browser..window
-           : Celsius &#(-> (getf@v 'Celsius) (X#.#"X*1.8+32") (set@v 'Fahrenheit))
-           Fahrenheit &#(-> (getf@v 'Fahrenheit) (X#.#"(X-32)/1.8") (set@v 'Celsius))))
-       (let (row (enjoin (tag "input id='{0}' onkeyup='{0}()'")
-                         (tag "label for='{0}'" "°{1}")))
-         (enjoin (.format row "Fahrenheit" "F")"<br>"(.format row "Celsius" "C")))))))
+((bottle..route "/") ; https://bottlepy.org
+ &#(enjoin
+    (let (s (tag "script src='https://cdn.jsdelivr.net/npm/brython@3/brython{}.js'"))
+      (enjoin (.format s ".min") (.format s "_stdlib")))
+    (tag "body onload='brython()'" ; Browser Python: https://brython.info
+     (script
+       (define getE X#(.getElementById browser..document X))
+       (define getf@v X#(float (@#value (getE X))))
+       (define set@v XY#(setattr (getE Y) 'value X))
+       (attach browser..window
+         : Celsius &#(-> (getf@v 'Celsius) (X#.#"X*1.8+32") (set@v 'Fahrenheit))
+         Fahrenheit &#(-> (getf@v 'Fahrenheit) (X#.#"(X-32)/1.8") (set@v 'Celsius))))
+     (let (row (enjoin (tag "input id='{0}' onkeyup='{0}()'")
+                       (tag "label for='{0}'" "°{1}")))
+       (enjoin (.format row "Fahrenheit" "F")"<br>"(.format row "Celsius" "C"))))))
 
 (bottle..run : host "localhost"  port 8080  debug True)
 ```

--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -1,3 +1,7 @@
+<!--
+Copyright 2022 Matthew Egan Odendahl
+SPDX-License-Identifier: Apache-2.0
+-->
 {% extends '!base.html' %}
 
 {% block extrahead %}
@@ -11,6 +15,46 @@
 <style type="text/css">
 .gitter-chat-embed {
   z-index: 401
+}
+</style>
+<style type="text/css">
+/* Contrast Tweaks for Monokai Theme */
+.highlight .gh {
+  color: hsl(212deg, 30%, 96%);
+  font-weight: bold;
+}
+.highlight .gu {
+  color: hsl(212deg, 30%, 96%);
+  font-style: italic;
+}
+.highlight .c {
+  color: hsl(212deg, 9%, 58%)
+}
+.highlight .c1 {
+  color: hsl(212deg, 9%, 58%)
+}
+.highlight {
+  background: #0d1117
+}
+</style>
+<style type="text/css">
+/* Dark-Theme Contrast Tweaks for Monokai Theme */
+body[data-theme="dark"] .highlight .gh {
+color: hsl(212deg, 30%, 96%);
+font-weight: bold;
+}
+body[data-theme="dark"] .highlight .gu {
+color: hsl(212deg, 30%, 96%);
+font-style: italic;
+}
+body[data-theme="dark"] .highlight .c {
+  color: hsl(212deg, 9%, 58%)
+}
+body[data-theme="dark"] .highlight .c1 {
+color: hsl(212deg, 9%, 58%)
+}
+body[data-theme="dark"] .highlight {
+background: #0d1117
 }
 </style>
 {% endblock %}

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -45,7 +45,7 @@ For example, using `hissp.reader.transpile`, a package name, and module names,
 
 .. code-block:: shell
 
-   $ alias lisspt='lissp -c '\''(hissp..transpile : :* (X#.#"X[1:]" sys..argv))'\'
+   $ alias lisspt="lissp -c '(hissp..transpile : :* ([#1:] sys..argv))'"
    $ lisspt pkg foo # Transpiles pkg/foo.lissp to pkg/foo.py in a package context.
    $ lisspt pkg.sub foo # Transpiles pkg/sub/foo.lissp to .py in subpackage context.
    $ lisspt "" foo bar # foo.lissp, bar.lissp to foo.py, bar.py without a package.
@@ -54,7 +54,7 @@ or using `hissp.reader.transpile_file`, a file name, and a package name,
 
 .. code-block:: shell
 
-   $ alias lissptf='lissp -c '\''(hissp.reader..transpile_file : :* (X#.#"X[1:]" sys..argv))'\'
+   $ alias lissptf="lissp -c '(hissp.reader..transpile_file : :* ([#1:] sys..argv))'"
    $ lissptf spam.lissp # Transpile a single file without a package.
    $ cd pkg
    $ lissptf eggs.lissp pkg # must declare the package name

--- a/docs/command_line_reference.rst
+++ b/docs/command_line_reference.rst
@@ -1,4 +1,4 @@
-.. Copyright 2020, 2021 Matthew Egan Odendahl
+.. Copyright 2020, 2021, 2022 Matthew Egan Odendahl
    SPDX-License-Identifier: CC-BY-SA-4.0
 
 Command Line Reference
@@ -9,7 +9,7 @@ Command Line Reference
 Lissp Command
 -------------
 
-A normal install of the ``hissp`` package with ``pip`` and ``setuptools`` will
+A normal install of the ``hissp`` package will
 also install the ``lissp`` command-line tool for running Lissp code.
 This is a convenience executable for starting ``python -m hissp``,
 whose minimal options were modeled after Python's most commonly used:
@@ -33,17 +33,30 @@ The Lissp Compiler
 ------------------
 
 The recommended way to compile Lissp modules is with
-`transpile <hissp.reader.transpile>` calls in ``__init__.py`` files (or the main module).
+`transpile <hissp.reader.transpile>` calls in ``__init__.py`` files
+for packaged modules,
+or in the main module for any modules not in a package.
 
-This can be done manually in the REPL.
-However, an external build system may need to use shell commands.
+One-offs are easy to do manually in the REPL,
+but an external build system may need to use shell commands.
 It is possible to run transpile commands in the shell via ``python -c`` or ``lissp -c``.
 
-For example, using `hissp.reader.transpile_file`,
+For example, using `hissp.reader.transpile`, a package name, and module names,
 
 .. code-block:: shell
 
-   $ alias lisspc="lissp -c '(hissp.reader..transpile_file : :* (get#(slice 1 None) sys..argv))'"
-   $ lisspc spam.lissp
-   $ cd foopackage
-   $ lisspc eggs.lissp foopackage
+   $ alias lisspt='lissp -c '\''(hissp..transpile : :* (X#.#"X[1:]" sys..argv))'\'
+   $ lisspt pkg foo # Transpiles pkg/foo.lissp to pkg/foo.py in a package context.
+   $ lisspt pkg.sub foo # Transpiles pkg/sub/foo.lissp to .py in subpackage context.
+   $ lisspt "" foo bar # foo.lissp, bar.lissp to foo.py, bar.py without a package.
+
+or using `hissp.reader.transpile_file`, a file name, and a package name,
+
+.. code-block:: shell
+
+   $ alias lissptf='lissp -c '\''(hissp.reader..transpile_file : :* (X#.#"X[1:]" sys..argv))'\'
+   $ lissptf spam.lissp # Transpile a single file without a package.
+   $ cd pkg
+   $ lissptf eggs.lissp pkg # must declare the package name
+   $ cd sub
+   $ lissptf ham.lissp pkg.sub # separate subpackage name with dot

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3358,6 +3358,9 @@ Lissp Whirlwind Tour
    #..It's a way to comment out code structurally.
    #..It can also make block comments like this one.
    #..This would show up when compiled if not for _#.
+   #..Of course, a string expression like this one wouldn't do anything
+   #..in Python, even if it were compiled in. But the need to escape double
+   #..quotes might make ;; comments easier.
    #.."
    >>>
 
@@ -3406,10 +3409,9 @@ Lissp Whirlwind Tour
    "Comment(content='comments are parsed objects too!')"
 
 
-   _#"Except for strings and tuples, objects in Hissp should evaluate to
-   themselves. But when the object lacks a Python literal notation,
-   the compiler is in a pickle!
-   "
+   ;; Except for strings and tuples, objects in Hissp should evaluate
+   ;; to themselves. But when the object lacks a Python literal notation,
+   ;; the compiler is in a pickle!
    #> builtins..float#inf
    >>> __import__('pickle').loads(  # inf
    ...     b'Finf\n.'
@@ -3419,10 +3421,9 @@ Lissp Whirlwind Tour
 
    ;;; 19.3 Inject
 
-   _#"The 'inject' reader macro compiles and evaluates the next form at
-   read time and injects the resulting object directly into the Hissp
-   tree, like a fully-qualified reader macro does.
-   "
+   ;; The 'inject' reader macro compiles and evaluates the next form at
+   ;; read time and injects the resulting object directly into the Hissp
+   ;; tree, like a fully-qualified reader macro does.
 
    #> '(1 2 (operator..add 1 2))          ;Quoting happens at compile time.
    >>> ((1),
@@ -3452,10 +3453,9 @@ Lissp Whirlwind Tour
    Fraction(1, 2)
 
 
-   _#"Recall that Hissp-level string objects can represent
-   arbitrary Python code. It's usually used for identifiers,
-   but can be anything, even complex formulas.
-   "
+   ;; Recall that Hissp-level string objects can represent
+   ;; arbitrary Python code. It's usually used for identifiers,
+   ;; but can be anything, even complex formulas.
    #> (lambda abc
    #..  ;; Hissp may not have operators, but Python does.
    #..  .#"(-b + (b**2 - 4*a*c)**0.5)/(2*a)")
@@ -3463,11 +3463,10 @@ Lissp Whirlwind Tour
    <function <lambda> at 0x...>
 
 
-   _#"Remember the raw string and hash string reader syntax makes Python-
-   level strings, via a Hissp-level string containing a Python string
-   literal. It is NOT for creating a Hissp-level string, which would
-   normally contain Python code. Use inject for that.
-   "
+   ;; Remember the raw string and hash string reader syntax makes Python-
+   ;; level strings, via a Hissp-level string containing a Python string
+   ;; literal. It is NOT for creating a Hissp-level string, which would
+   ;; normally contain Python code. Use inject for that.
    #> '"a string"                         ;Python code for a string. In a string.
    >>> "('a string')"
    "('a string')"
@@ -3478,9 +3477,8 @@ Lissp Whirlwind Tour
    'a string'
 
 
-   _#"Objects without literals don't pickle until the compiler has to emit
-   them as Python code. That may never happen if another macro gets there first.
-   "
+   ;; Objects without literals don't pickle until the compiler has to emit
+   ;; them as Python code. That may never happen if another macro gets it.
    #> 'builtins..repr#(re..compile#.#"[1-9][0-9]*" builtins..float#inf)
    >>> "(re.compile('[1-9][0-9]*'), inf)"
    "(re.compile('[1-9][0-9]*'), inf)"
@@ -3899,14 +3897,13 @@ Lissp Whirlwind Tour
 
    ;;; 20.1 Aside: Extra (!), the Final Builtin Reader Macro
 
-   _#"Reader macros take one primary argument, but additional arguments
-   can be passed in with the extra macro !. A reader macro consumes the
-   next parsed object, and if it's an Extra, consumes one again. Thus,
-   extras must be written between the # and primary argument, but because
-   they're often optional refinements, which are easier to define as
-   trailing optional parameters in Python functions, they get passed
-   in after the primary argument.
-   "
+   ;; Reader macros take one primary argument, but additional arguments
+   ;; can be passed in with the extra macro !. A reader macro consumes the
+   ;; next parsed object, and if it's an Extra, consumes one again. Thus,
+   ;; extras must be written between the # and primary argument, but
+   ;; because they're often optional refinements, which are easier to
+   ;; define as trailing optional parameters in Python functions, they get
+   ;; passed in after the primary argument.
    #> (setattr _macro_ 'L\# en#list)
    >>> setattr(
    ...   _macro_,

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3852,17 +3852,20 @@ Lissp Whirlwind Tour
    ...   (5),
    ...   # hissp.._macro_._spy
    ...   # hissp.macros.._macro_.let
-   ...   (lambda _QzNo70_e=mul(
+   ...   (lambda _QzNo71_e=mul(
    ...     (7),
    ...     (3)):(
    ...     __import__('builtins').print(
-   ...       ('mul',
-   ...        (7),
-   ...        (3),),
+   ...       __import__('pprint').pformat(
+   ...         ('mul',
+   ...          (7),
+   ...          (3),),
+   ...         sort_dicts=(0)),
    ...       ('=>'),
-   ...       _QzNo70_e,
+   ...       __import__('builtins').repr(
+   ...         _QzNo71_e),
    ...       file=__import__('sys').stderr),
-   ...     _QzNo70_e)[-1])())
+   ...     _QzNo71_e)[-1])())
    26
 
    ;; stderr: ('mul', 7, 3) => 21

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -679,7 +679,7 @@ Lissp Whirlwind Tour
    ;;;; 10 Advanced Lambdas
 
    ;; Python parameter types are rather involved. Lambda does all of them.
-   ;; Like calls, they are all paired. :? means no default.
+   ;; Like calls, they are all pairs. :? means no default.
    #> (lambda (: a :?  b :?  :/ :?        ;positional only
    #..         c :?  d :?                 ;normal
    #..         e 1  f 2                   ;default

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3827,24 +3827,31 @@ Lissp Whirlwind Tour
    ...   # hissp.macros.._macro_.letQz_from
    ...   (lambda _QzNo73_start,_QzNo73_val,_QzNo73_end:(
    ...     __import__('builtins').print(
-   ...       ('Elapsed:'),
+   ...       ('time# ran'),
+   ...       __import__('pprint').pformat(
+   ...         ('time..sleep',
+   ...          (0.05),),
+   ...         sort_dicts=(0)),
+   ...       ('in'),
    ...       __import__('operator').truediv(
    ...         __import__('operator').sub(
    ...           _QzNo73_end,
    ...           _QzNo73_start),
    ...         __import__('decimal').Decimal(
    ...           (1000000.0))),
-   ...       ('ms')),
+   ...       ('ms'),
+   ...       file=__import__('sys').stderr),
    ...     _QzNo73_val)[-1])(
    ...     *# hissp.macros.._macro_.QzAT_
-   ...      (lambda *_QzNo42_xs:
+   ...      (lambda *_QzNo55_xs:
    ...        __import__('builtins').list(
-   ...          _QzNo42_xs))(
+   ...          _QzNo55_xs))(
    ...        _QzNo73_time(),
    ...        __import__('time').sleep(
    ...          (0.05)),
    ...        _QzNo73_time())))()
-   Elapsed: ... ms
+
+   ;; stderr: time# ran ('time..sleep', 0.05) in ... ms
 
 
    #> (add 5 spy#(mul 7 3))                  ;Debug subexpressions.

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -1269,7 +1269,7 @@ But let's look at this Lissp snippet again, more carefully.
                     (range 27)))
 
 It's injecting some Hissp we generated with a template.
-That's the first two reader macros ``.#`` and :literal:`\``.
+Those are the first two reader macros ``.#`` (inject) and :literal:`\`` (template quote).
 The `progn` sequences multiple expressions for their side effects.
 It's like having multiple "statements" in a single expression.
 We splice in multiple expressions generated with a `map`.

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -2847,18 +2847,20 @@ A Slice of Python
 -----------------
 
 Python has a powerful and compact notation for operating on *slices* of sequences.
+It has three arguments: *start*, *stop*, and *step*.
+Each one is optional, and defaults to ``None``.
 
 .. code-block:: Python
 
    >>> "abcdefg"[-1::-2]
    'geca'
 
-It has three arguments: *start*, *stop*, and *step*.
-Each one is optional, and defaults to ``None``.
 
 However, this notation is only valid in the context of a subscription operator ``[]``.
 It is possible to separate the operands using the `slice` builtin,
 but it comes at a cost.
+
+(We'll be reusing this simple "geca" test case as we iterate. Feel free to try others.)
 
 .. code-block:: Python
 
@@ -2867,7 +2869,7 @@ but it comes at a cost.
    >>> a[b]
    'geca'
 
-We can see that the slice notation is much more compact than this approach.
+There's the cost: this separated approach is much less concise compared to the slice notation.
 
 Even without macros,
 Hissp can slice this way.
@@ -2887,7 +2889,16 @@ This is so much longer that one would be tempted to inject the Python version.
 Unfortunately, the rest of the expression is often easier to write in Lissp.
 You can usually work around this by using
 `let` to give an easily-injectable name to a complex operand,
-but that adds as much overhead as `slice` would.
+but that adds as significant overhead.
+
+.. code-block:: REPL
+
+   #> (let (x "abcdefg") .#"x[-1::-2]")
+   >>> # let
+   ... (lambda x=('abcdefg'):x[-1::-2])()
+   'geca'
+
+.. TODO: (X#.#"X[-1::-2]" "abcdefg")
 
 We need a better abstraction.
 
@@ -3207,8 +3218,217 @@ These cases are very common.
 
 For more complex expressions, it's probably a bad idea.
 You lose out on munging, module handles, and any macros.
-For those cases, the extra overhead for using `slice` is hardly noticable.
+For those cases, the extra overhead for using `slice` is hardly noticeable.
 Use the right tool for the job.
+
+A Simpler Solution
+~~~~~~~~~~~~~~~~~~
+
+The `itemgetter <operator.itemgetter>` function is a function factory;
+it's a function to make functions, at run time.
+Using run time helpers like this is an important technique for writing macros,
+but sometimes more work can be done at compile time.
+
+.. TODO: (X#.#"X[-1::-2]" "abcdefg")
+
+If we write a lambda form ourselves,
+it's not necessary to separate the operands for the subscription operator,
+which means we don't need the ``Slicer`` helper class either.
+
+Compare.
+
+.. code-block:: REPL
+
+   #> ((op#itemgetter (slice -1 None -2)) "abcdefg")
+   >>> __import__('operator').itemgetter(
+   ...   slice(
+   ...     (-1),
+   ...     None,
+   ...     (-2)))(
+   ...   ('abcdefg'))
+   'geca'
+
+   #> ((lambda a .#"a[-1::-2]") "abcdefg")
+   >>> (lambda a:a[-1::-2])(
+   ...   ('abcdefg'))
+   'geca'
+
+We'd be giving up a little transparency.
+Notice the nice `repr` provided by the `operator.itemgetter`.
+
+.. code-block:: REPL
+
+   #> (op#itemgetter (slice -1 None -2))
+   >>> __import__('operator').itemgetter(
+   ...   slice(
+   ...     (-1),
+   ...     None,
+   ...     (-2)))
+   operator.itemgetter(slice(-1, None, -2))
+
+The lambda object, on the other hand, is opaque.
+
+.. code-block:: REPL
+
+   #> (lambda a .#"a[-1::-2]")
+   >>> (lambda a:a[-1::-2])
+   <function <lambda> at 0x...>
+
+But if we can eliminate the ``Slicer`` this is probably worth it.
+
+We can pretty easily expand to this form.
+Our previous macro was almost there.
+
+.. Lissp::
+
+   #> (defmacro \[\# e
+   #..  `(lambda ,'a ,(.format "({}[{})" 'a (hissp..demunge e))))
+   >>> # defmacro
+   ... # hissp.macros.._macro_.let
+   ... (lambda _QzNo7_fn=(lambda e:
+   ...   (lambda * _: _)(
+   ...     'lambda',
+   ...     'a',
+   ...     ('({}[{})').format(
+   ...       'a',
+   ...       __import__('hissp').demunge(
+   ...         e)))):(
+   ...   __import__('builtins').setattr(
+   ...     _QzNo7_fn,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_',
+   ...        'QzLSQB_QzHASH_',))),
+   ...   __import__('builtins').setattr(
+   ...     __import__('operator').getitem(
+   ...       __import__('builtins').globals(),
+   ...       '_macro_'),
+   ...     'QzLSQB_QzHASH_',
+   ...     _QzNo7_fn))[-1])()
+
+It works.
+
+.. code-block:: REPL
+
+   #> (.\[\# _macro_ '-1::-2]) ; shows Hissp expansion for [#-1::-2]
+   >>> _macro_.QzLSQB_QzHASH_(
+   ...   'Qz_1QzCOLON_QzCOLON_Qz_2QzRSQB_')
+   ('lambda', 'a', '(a[-1::-2])')
+
+   #> ([#-1::-2] "abcdefg")
+   >>> (lambda a:(a[-1::-2]))(
+   ...   ('abcdefg'))
+   'geca'
+
+Maybe even better than expected.
+
+.. code-block:: REPL
+
+   #> ([#1][1] '(foo bar))
+   >>> (lambda a:(a[1][1]))(
+   ...   ('foo',
+   ...    'bar',))
+   'a'
+
+Everything in the atom after the ``#`` is Python code.
+The initial ``[`` does have to be closed,
+but after that,
+other Python expressions work too.
+
+The format string could even be simplified to ``"(a[{})"``,
+but there's a subtle flaw which is reason enough not to follow through with that.
+
+.. code-block:: REPL
+
+   #> (let (a -1)
+   #..  ([#a::-2] "abcdefg"))
+   >>> # let
+   ... (lambda a=(-1):
+   ...   (lambda a:(a[a::-2]))(
+   ...     ('abcdefg')))()
+   Traceback (most recent call last):
+     ...
+   TypeError: slice indices must be integers or None or have an __index__ method
+
+Yet it works fine with ``b``.
+
+.. code-block:: REPL
+
+   #> (let (b -1)
+   #..  ([#b::-2] "abcdefg"))
+   >>> # let
+   ... (lambda b=(-1):
+   ...   (lambda a:(a[b::-2]))(
+   ...     ('abcdefg')))()
+   'geca'
+
+See the problem?
+Look at the Python compilation.
+Our ``slicer`` version didn't have this flaw.
+
+Auto-qualification isn't compatible with local variables,
+but since we didn't want this accidental anaphor,
+we should suppress the qualification with a gensym instead of a symbol interpolation.
+
+.. Lissp::
+
+   #> (defmacro \[\# e
+   #..  `(lambda ($#G) ,(.format "({}[{})" '$#G (hissp..demunge e))))
+   >>> # defmacro
+   ... # hissp.macros.._macro_.let
+   ... (lambda _QzNo7_fn=(lambda e:
+   ...   (lambda * _: _)(
+   ...     'lambda',
+   ...     (lambda * _: _)(
+   ...       '_QzNo26_G'),
+   ...     ('({}[{})').format(
+   ...       '_QzNo26_G',
+   ...       __import__('hissp').demunge(
+   ...         e)))):(
+   ...   __import__('builtins').setattr(
+   ...     _QzNo7_fn,
+   ...     '__qualname__',
+   ...     ('.').join(
+   ...       ('_macro_',
+   ...        'QzLSQB_QzHASH_',))),
+   ...   __import__('builtins').setattr(
+   ...     __import__('operator').getitem(
+   ...       __import__('builtins').globals(),
+   ...       '_macro_'),
+   ...     'QzLSQB_QzHASH_',
+   ...     _QzNo7_fn))[-1])()
+
+Read this carefully.
+``$#`` only works inside of templates,
+but it's still allowed in an unquote context inside of a template;
+the template context hasn't completely turned off.
+`unquote_context` and `gensym_context` are both tracked by the reader.
+
+Since we want the symbol itself,
+not its value,
+we need to quote it with ``'``.
+Remember, reader macros apply inside-out,
+like functions,
+so the ``$#`` macro applies *before* the ``'`` does.
+
+It works.
+
+.. code-block:: REPL
+
+   #> ([#-1::-2] "abcdefg")
+   >>> (lambda _QzNo26_G:(_QzNo26_G[-1::-2]))(
+   ...   ('abcdefg'))
+   'geca'
+
+Notice the gensym in the expansion (your template number may be diferent than mine),
+which would prevent the kind of accidental name collision we saw in our `let` ``a`` example.
+
+And *this* is the `bundled version <QzLSQB_QzHASH_>`, sans docstring.
+It has no dependencies; no helpers.
+Now you understand how it works, know its limitations,
+its tricks,
+and how to implement it yourself.
+Superpower stolen.
 
 .. TODO: fractions
    (defmacro F\# (x)

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -625,7 +625,7 @@ use a dedent string, which can be safely indented:
 This required an inject ``.#``.
 Don't forget the quote ``'``.
 
-With the possible exception of docstrings,
+With the principal exception of docstrings,
 long multiline strings should be declared at the `top level`_ and referenced by name.
 
 .. code-block:: Lissp

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -558,7 +558,7 @@ because the string's structure is more important for readability than the tuple'
 
    (enjoin                                ;Preferred.
      "Weather in "location" for "date" will be "weather"
-    with a "chance"% of rain.")
+    with a "percent"% chance of rain.")
 
    (enjoin "Weather in "                  ;OK.
            location
@@ -568,8 +568,8 @@ because the string's structure is more important for readability than the tuple'
            weather
            "
      with a "                             ;OK, but would look better with \n.
-           chance
-           "% of rain.")
+           percent
+           "% chance of rain.")
 
 Exactly where the implied groups are can depend on the function's semantics,
 not just the fact that it's a call.

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -243,7 +243,7 @@ you may have to turn it off.
 Note also that tuple commas are used as terminators,
 not separators,
 even on the same line.
-This is to prevent the common error of forgetting the required trailing comma for a single.
+This is to prevent the common error of forgetting the required trailing comma for a monuple.
 If your syntax highlighter can distinguish ``(x)`` from ``(x,)``, you may be OK without it.
 But this had better be the case for the whole team.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -1989,7 +1989,7 @@ with the name of each top-level ``.lissp`` file,
 or ``.lissp`` file in the corresponding package,
 respectively::
 
-   from hissp.reader import transpile
+   from hissp import transpile
 
    transpile(__package__, "spam", "eggs", "etc")
 
@@ -1997,22 +1997,40 @@ Or equivalently in Lissp, used either at the REPL or if the main module is writt
 
 .. code-block:: Lissp
 
-   (hissp.reader..transpile __package__ 'spam 'eggs 'etc)
+   (hissp..transpile __package__ 'spam 'eggs 'etc)
 
-This will automatically compile each named Lissp module.
-This approach gives you fine-grained control over what gets compiled when.
-If desired, you can remove a name passed to the `transpile()`
-call to stop recompiling that file.
-Then you can compile the file manually at the REPL as needed using `transpile()`.
+This will automatically compile each named Lissp module,
+which gives you fine-grained control over what gets compiled when.
 
-Note that you usually *would* want to recompile the whole project
-rather than only the changed files on import like Python does for ``.pyc`` files,
-because macros run at compile time.
+.. sidebar:: The Lissp source for `hissp.macros`
+
+   is included in the distributed Hissp package for completeness,
+   but Hissp doesn't automatically recompile it on import.
+   If you do an
+   `editable install <https://setuptools.pypa.io/en/latest/userguide/development_mode.html>`_
+   don't forget to recompile it when making changes!
+
+Before distributing a Lissp project to users who won't be modifying it,
+compilation could be disabled or removed altogether,
+especially when not distributing the .lissp sources.
+
+.. Note::
+   You normally *do* want to recompile the whole project during development.
+   CPython only needs to recompile any changed ``.py`` files to ``.pyc``,
+   but because macros run at compile time,
+   this wouldn't work well for Lissp.
+
 Changing a macro in one file normally doesn't affect the code that uses
 it in other files until they are recompiled.
 That is why `transpile()` will recompile the named files unconditionally.
 Even if the corresponding source has not changed,
 the compiled output may be different due to an updated macro in another file.
+
+Fortunately, Lissp compilation is usually pretty fast,
+but if desired (perhaps due to a slow macro),
+you can remove a name passed to the `transpile()`
+call to stop recompiling that file.
+Then you can compile the file manually at the REPL as needed using `transpile()`.
 
 Unicode Normalization
 =====================

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -714,7 +714,7 @@ Python's parameter types are rather involved.
 Hissp's lambdas have a simplified format designed for metaprogramming.
 When the parameters tuple [#LambdaList]_
 starts with a colon,
-then all parameters are paired.
+then all parameters are pairs.
 Hissp can represent all of Python's parameter types this way.
 
 .. code-block:: REPL
@@ -773,7 +773,7 @@ of a pair with a ``:?``.
 Each element before the ``:`` is implicitly paired with
 the placeholder control word ``:?``.
 Notice the Python compilation is exactly the same as before,
-and that a ``:?`` was still required in the paired section to indicate that the
+and that a ``:?`` was still required in the pairs section to indicate that the
 ``i`` parameter has no default value.
 
 The ``:*`` and ``:**`` control words mark their parameters as
@@ -814,9 +814,9 @@ in which case an empty tuple is implied:
    <function <lambda> at ...>
 
 Positional-only parameters with defaults must appear after the ``:``,
-which forces the ``:/`` into the paired side.
-Everything on the paired side must be paired, no exceptions.
-(Even though ``:/`` can only be paired with ``:?``,
+which forces the ``:/`` into the pairs side.
+Everything on the pairs side must be paired, no exceptions.
+(Even though ``:/`` can only pair with ``:?``,
 adding another special case to not require the ``:?``
 would make metaprogramming more difficult.)
 
@@ -861,7 +861,7 @@ The remaining elements are for the arguments.
 
 Like lambda's parameters tuple,
 when you start the arguments with ``:``,
-the rest are paired.
+the rest are pairs.
 
 .. code-block:: REPL
 
@@ -887,7 +887,7 @@ this means that the ``:?`` is always the left of a pair.
 Like lambdas, the ``:`` is a convenience abbreviation for ``:?`` pairs,
 giving call forms three parts::
 
-   (<callable> <single> : <paired>)
+   (<callable> <singles> : <pairs>)
 
 For example:
 
@@ -905,7 +905,7 @@ For example:
 
 Notice the Python compilation is exactly the same as before.
 
-The single and the paired section may be empty:
+The singles or the pairs section may be empty:
 
 .. code-block:: REPL
 
@@ -924,7 +924,7 @@ The single and the paired section may be empty:
    ...   end=('X'))
    X
 
-The ``:`` is optional if the paired section is empty:
+The ``:`` is optional if the pairs section is empty:
 
 .. code-block:: REPL
 
@@ -939,7 +939,7 @@ The ``:`` is optional if the paired section is empty:
 
 Again, this is like lambda.
 
-The paired section has implicit pairs; there must be an even number.
+The pairs section has implicit pairs; there must be an even number of elements.
 
 Use the control words ``:*`` for iterable unpacking,
 ``:?`` to pass by position, and ``:**`` for keyword unpacking:
@@ -966,7 +966,7 @@ but (as in Python) a ``:*`` is not allowed to follow ``:**``.
 
 Method calls are similar to function calls::
 
-   (.<method name> <self> <single> : <paired>)
+   (.<method name> <self> <singles> : <pairs>)
 
 Like Clojure, a method on the first "argument" (``<self>``) is assumed if the
 function name starts with a dot:

--- a/setup.py
+++ b/setup.py
@@ -64,4 +64,4 @@ setuptools.setup(
     entry_points={"console_scripts": ["lissp=hissp.__main__:main"]},
 )
 # Build dist and install:
-# python setup.py bdist_wheel && pip install --force-reinstall dist\hissp-*.whl
+# python setup.py bdist_wheel && pip install --force-reinstall setup\dist\hissp-*.whl

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -151,7 +151,7 @@ class Compiler:
         (lambda (<parameters>)
           <body>)
 
-        The parameters tuple is divided into (<single> : <paired>)
+        The parameters tuple is divided into (<singles> : <pairs>)
 
         Parameter types are the same as Python's.
         For example,
@@ -201,7 +201,7 @@ class Compiler:
         >>> readerless(('lambda', (),),)
         '(lambda :())'
 
-        The ``:`` is required if there are any paired parameters, even
+        The ``:`` is required if there are any pair parameters, even
         if there are no single parameters:
 
         >>> readerless(('lambda', (':',':**','kwargs',),),)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -33,11 +33,12 @@ not be available for ``defmacro``. It's smart enough to check for the
 presence of ``_macro_`` (at compile time) in its expansion context, and
 inline the initialization code when required.
 
-With the exception of `prelude` (which uses `exec`), they also eschew
-any expansions to Python code, relying only on the built-in special
-forms ``quote`` and ``lambda``, which makes their expansions compatible
-with advanced rewriting macros that process the Hissp expansions of
-other macros.
+With the exception of `prelude` (which uses `exec`), and
+`subscript <QzLSQB_QzHASH_>`, which is not used internally, they also
+eschew any expansions to Python code, relying only on the built-in
+special forms ``quote`` and ``lambda``, which makes their expansions
+compatible with advanced rewriting macros that process the Hissp
+expansions of other macros.
 
 To help keep macro definitions and expansions manageable in complexity,
 these macros lack some of the extra features their equivalents
@@ -754,3 +755,7 @@ except ModuleNotFoundError:pass"
          (throw (AssertionError ,@args)))
        ,'it)
     e))
+
+(defmacro \[\# e
+  "``subscript`` Injection. Python's subscription operator."
+  `(lambda ($#G) ,(.format "({}[{})" '$#G (hissp..demunge e))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -736,12 +736,16 @@ except ModuleNotFoundError:pass"
   `(hissp.._macro_._spy ,e))
 
 (defmacro time\# e
-  "``time#`` Measure execution time of e, return its value."
+  "``time#`` Print ms elapsed running e to stderr. Return its value."
   `(let ($#time time..time_ns)
      (let-from ($#start $#val $#end) (@ ($#time) ,e ($#time))
-       (print "Elapsed:" (op#truediv (op#sub $#end $#start)
-                                     (decimal..Decimal 1e6))
-                         "ms")
+       (print "time# ran"
+              (pprint..pformat ',e : sort_dicts 0)
+              "in"
+              (op#truediv (op#sub $#end $#start)
+                          (decimal..Decimal 1e6))
+              "ms"
+              : file sys..stderr)
        $#val)))
 
 (defmacro ensure (e predicate : :* args)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -725,7 +725,10 @@ except ModuleNotFoundError:pass"
 
 (defmacro _spy e
   `(let ($#e ,e)
-     (print ',e "=>" $#e : file sys..stderr)
+     (print (pprint..pformat ',e : sort_dicts 0)
+            "=>"
+            (repr $#e)
+            : file sys..stderr)
      $#e))
 
 (defmacro spy\# e

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -729,7 +729,7 @@ except ModuleNotFoundError:pass"
      $#e))
 
 (defmacro spy\# e
-  "``spy#`` Print e => its value to stderr, return the value."
+  "``spy#`` Print e => its value to stderr. Return the value."
   `(hissp.._macro_._spy ,e))
 
 (defmacro time\# e
@@ -747,7 +747,7 @@ except ModuleNotFoundError:pass"
   Additional arguments are evaluated in a context where ``it`` refers
   to the result of e. These (if any) are passed to the AssertionError.
 
-  Compilation is simply the it when __debug__ is off.
+  Compilation is simply e when __debug__ is off.
   "
   (if-else __debug__
     `(let (,'it ,e)

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -248,14 +248,14 @@ class Lissp:
     def _macro(self, v):
         p = self._p
         with {
-            "`": self.template_context,
+            "`": self.gensym_context,
             ",": self.unquote_context,
             ",@": self.unquote_context,
         }.get(v, nullcontext)():
             yield self.parse_macro(v, *self._extras(p, v))
 
     @contextmanager
-    def template_context(self):
+    def gensym_context(self):
         """Start a new gensym context for the current template."""
         self.counters.append(gensym_counter())
         self.context.append("`")

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -71,7 +71,7 @@ DROP = object()
 """
 The sentinel value returned by the discard macro ``_#``, which the
 reader skips over when parsing. Reader macros can have read-time side
-effects with no Hissp output by returning this.
+effects with no Hissp output by returning this. (Not recommended.)
 """
 
 
@@ -125,10 +125,18 @@ class Lexer(Iterator):
 
 _Unquote = namedtuple("_Unquote", ["target", "value"])
 Comment = namedtuple("Comment", ["content"])
+"""Parsed object for a comment.
+
+The reader normally discards these, but reader macros can use them.
+The content does not include the initial semicolon.
+"""
 
 
 class Extra(tuple):
-    """Designates Extra read-time arguments for reader macros."""
+    """Designates Extra read-time arguments for reader macros.
+
+    Normally made with the ``!`` macro, but can be constructed directly.
+    """
 
     def __repr__(self):
         return f"Extra({list(self)!r})"
@@ -473,9 +481,9 @@ def _parse_extras(extras):
 def is_qualifiable(symbol):
     """Determines if symbol can be qualified with a module.
 
-    Can't be ``quote``, ``__import__``, any Python reserved word, an
-    auto-gensym, already qualified, method syntax, or a module handle;
-    and must be a valid identifier or attribute identifier.
+    Can't be ``quote``, ``__import__``, any Python reserved word, a
+    prefix auto-gensym, already qualified, method syntax, or a module
+    handle; and must be a valid identifier or attribute identifier.
     """
     return (
         symbol not in {"quote", "__import__"}
@@ -510,7 +518,7 @@ def transpile_file(path: Union[Path, str], package: Optional[str] = None):
     Code in .lissp files is executed upon compilation. This is necessary
     because macro definitions can alter the compilation of subsequent
     top-level forms. A packaged Lissp file must know its package at
-    compile time to resolve imports correctly.
+    compile time to handle templates and macros correctly.
     """
     path = Path(path).resolve(strict=True)
     qualname = f"{package or ''}{'.' if package else ''}{PurePath(path.name).stem}"


### PR DESCRIPTION
Python slices! This one does an injection, but it should be fairly well contained most of the time and it's just too useful to omit. I avoided using it in the macro definitions, although it certainly would have simplified a number of places. I also added to the macro tutorial explaining how to implement this one.

I also reworked the code theme in the docs for better contrast. The default Monokai comments are a little to faint for how much I'm using them.

`spy#` and `time#` now pretty-print. This complicates the macros, but just a bit. Not sure if it's worth it yet.

Lots of other doc improvements.