### PR TITLE
More doc editing and associated improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ python -m pip install --upgrade git+https://github.com/gilch/hissp
 Confirm install with
 ```
 python -m hissp --help
+lissp -c "__hello__."
 ```
 
 # Examples!

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2273,7 +2273,6 @@ Lissp Whirlwind Tour
    ... # hissp.macros..QzMaybe_.Qz_QzGT_
    ... # hissp.macros..QzMaybe_.Qz_QzGT_
    ... # Qz_QzGT_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_QzGT_
    ... print(
    ...   ('Hello'),
    ...   ('world!').title())

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -1844,8 +1844,7 @@ Lissp Whirlwind Tour
    >>> # deftype
    ... # hissp.macros.._macro_.define
    ... __import__('builtins').globals().update(
-   ...   Point2D=# hissp.macros..QzMaybe_.Qz_QzGT_
-   ...           __import__('builtins').type(
+   ...   Point2D=__import__('builtins').type(
    ...             'Point2D',
    ...             (lambda * _: _)(
    ...               tuple),
@@ -1866,45 +1865,6 @@ Lissp Whirlwind Tour
    ...   (1),
    ...   (2))
    Point2D(1, 2)
-
-
-   #> (deftype@ ((lambda (cls)
-   #..             (setattr cls 's (operator..concat cls.s "Out"))
-   #..             cls)
-   #..           (lambda (cls)
-   #..             (setattr cls 's (operator..concat cls.s "Inside"))
-   #..             cls))
-   #..          Decorated ()
-   #..  s "@")
-   >>> # deftypeQzAT_
-   ... # hissp.macros.._macro_.define
-   ... __import__('builtins').globals().update(
-   ...   Decorated=# hissp.macros..QzMaybe_.Qz_QzGT_
-   ...             (lambda cls:(
-   ...               setattr(
-   ...                 cls,
-   ...                 's',
-   ...                 __import__('operator').concat(
-   ...                   cls.s,
-   ...                   ('Out'))),
-   ...               cls)[-1])(
-   ...               (lambda cls:(
-   ...                 setattr(
-   ...                   cls,
-   ...                   's',
-   ...                   __import__('operator').concat(
-   ...                     cls.s,
-   ...                     ('Inside'))),
-   ...                 cls)[-1])(
-   ...                 __import__('builtins').type(
-   ...                   'Decorated',
-   ...                   (lambda * _: _)(),
-   ...                   __import__('builtins').dict(
-   ...                     s=('@'))))))
-
-   #> Decorated.s
-   >>> Decorated.s
-   '@InsideOut'
 
 
    ;; Define a function in the _macro_ namespace.

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3613,7 +3613,7 @@ Lissp Whirlwind Tour
    Help on function <lambda> in module hissp.macros:
    <BLANKLINE>
    <lambda> lambda raw
-       ``b#`` bytes literal reader macro
+       ``b#`` `bytes` literal reader macro
    <BLANKLINE>
 
 

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -1880,8 +1880,6 @@ Lissp Whirlwind Tour
    ... # hissp.macros.._macro_.define
    ... __import__('builtins').globals().update(
    ...   Decorated=# hissp.macros..QzMaybe_.Qz_QzGT_
-   ...             # hissp.macros..QzMaybe_.Qz_QzGT_
-   ...             # hissp.macros..QzMaybe_.Qz_QzGT_
    ...             (lambda cls:(
    ...               setattr(
    ...                 cls,
@@ -2270,8 +2268,6 @@ Lissp Whirlwind Tour
    #..    (.title)
    #..    (->> (print "Hello")))          ;Thread-last
    >>> # Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
    ... # Qz_QzGT_QzGT_
    ... print(
    ...   ('Hello'),
@@ -2833,10 +2829,7 @@ Lissp Whirlwind Tour
    ...       __import__('operator').not_(
    ...         test))())(
    ...     # hissp.macros.._macro_.Qz_QzGT_
-   ...     # hissp.macros..QzMaybe_.Qz_QzGT_
    ...     # Qz_QzGT_
-   ...     # hissp.macros..QzMaybe_.Qz_QzGT_
-   ...     # hissp.macros..QzMaybe_.Qz_QzGT_
    ...     eq(
    ...       mod(
    ...         it,
@@ -3160,9 +3153,6 @@ Lissp Whirlwind Tour
 
    #> (-> '(1 2 3) (recycle) (islice 7) (list))
    >>> # Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
    ... list(
    ...   islice(
    ...     recycle(

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2265,7 +2265,7 @@ Lissp Whirlwind Tour
    ;;; 15.6 Threading
 
    #> (-> "world!"                        ;Thread-first
-   #..    (.title)
+   #..    .title
    #..    (->> (print "Hello")))          ;Thread-last
    >>> # Qz_QzGT_
    ... # Qz_QzGT_QzGT_
@@ -3151,7 +3151,7 @@ Lissp Whirlwind Tour
    ...                     (1)),
    ...                   _QzNo31_target)[-1])()))))
 
-   #> (-> '(1 2 3) (recycle) (islice 7) (list))
+   #> (-> '(1 2 3) recycle (islice 7) list)
    >>> # Qz_QzGT_
    ... list(
    ...   islice(

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -40,11 +40,6 @@ Lissp Whirlwind Tour
 
    Familiarity with another Lisp dialect is not assumed, but helpful. If
    you get confused or stuck, the Hissp tutorial is easier.
-
-   Some examples depend on state set by previous examples to work.
-   Prerequisites for examples not in the same section are marked with
-   '/!\'. Don't skip these! If you resume with a new REPL session,
-   re-enter them, but only up to your current section.
    "
 
    ;;;; 2 Installation
@@ -503,9 +498,12 @@ Lissp Whirlwind Tour
    ...   (2))
    42
 
-   #> (.update (globals) : + operator..add) ;/!\ Assignment. Identifier munged.
+
+   ;; We'll be reusing this one in later sections.
+   #> (.update (globals) : + operator..add) ;Assignment. Identifier munged.
    >>> globals().update(
    ...   QzPLUS_=__import__('operator').add)
+
 
    #> (+ 40 2)                            ;No operators. This is still a function call!
    >>> QzPLUS_(
@@ -1020,6 +1018,7 @@ Lissp Whirlwind Tour
    ;; When your intent is to create data rather than code, unquote
    ;; each element.
 
+   ;; (Uses `+` from §8.1.)
    #> (list `(,@"abc"
    #..        ,1
    #..        ,(+ 1 1)
@@ -1183,6 +1182,9 @@ Lissp Whirlwind Tour
    ;; The REPL's default _macro_ namespace already has the bundled macros.
    (help _macro_.define)
 
+   ;;; 13.1 Macro Technique
+
+   ;; (Examples here use `+` from §8.1.)
 
    #> (setattr _macro_
    #..         'triple
@@ -2288,8 +2290,10 @@ Lissp Whirlwind Tour
    ;; imports a copy of hissp.macros.._macro_ (if available). Usually the
    ;; first form in a file, because it overwrites _macro_, but completely
    ;; optional. Implied for $ lissp -c commands.
-   #> (prelude)                           ;/!\ Or (hissp.._macro_.prelude)
-   >>> # prelude
+
+   ;; N.B. Sections after this one may require the prelude to work!
+   #> (hissp.._macro_.prelude)            ;Or just (prelude) in the REPL.
+   >>> # hissp.._macro_.prelude
    ... __import__('builtins').exec(
    ...   ('from functools import partial,reduce\n'
    ...    'from itertools import *;from operator import *\n'
@@ -2865,7 +2869,7 @@ Lissp Whirlwind Tour
 
    ;;; 15.10 Obligatory Factorial III
 
-   ;; With the prelude, we can define a nicer-looking version.
+   ;; With the prelude (§15.7), we can define a nicer-looking version.
    #> (define factorial-III
    #..  (lambda i
    #..    (if-else (le i 1)
@@ -2900,7 +2904,7 @@ Lissp Whirlwind Tour
 
    ;;;; 16 Exception handling
 
-   ;; Defined by the prelude. Guards against the targeted exception classes.
+   ;; Defined by the prelude (§15.7). Guards against targeted exceptions.
    #> (engarde `(,FloatingPointError ,ZeroDivisionError)               ;two targets
    #..         (lambda e (print "Oops!") e)                            ;handler (returns exception)
    #..         truediv 6 0)                                            ;calls it on your behalf
@@ -3016,8 +3020,8 @@ Lissp Whirlwind Tour
 
    ;;;; 17 Generators
 
-   ;; Defined by the prelude, Ensue gives you infinite lazy iterables,
-   ;; easy as recursion. Compare to loop-from.
+   ;; Defined by the prelude (§15.7), Ensue gives you infinite lazy
+   ;; iterables, easy as recursion. Compare to loop-from (§15.8).
    #> (define fibonacci
    #..  (lambda (: a 1  b 1)
    #..    (Ensue (lambda (step)
@@ -3496,6 +3500,11 @@ Lissp Whirlwind Tour
 
 
    ;;;; 20 The Bundled Reader Macros
+
+   ;; Like the other bundled macros, these are available in the REPL by
+   ;; default, but most other contexts, like .lissp files, require fully-
+   ;; qualified names. The prelude (§15.7) is the easiest way to add the
+   ;; bundled macros to a module.
 
    #> (reduce XY#(add Y X) "abcd")        ;Binary anaphoric lambda.
    >>> reduce(

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -1566,8 +1566,7 @@ Lissp can do that with a class.
    >>> # deftype
    ... # hissp.macros.._macro_.define
    ... __import__('builtins').globals().update(
-   ...   Flattener=# hissp.macros..QzMaybe_.Qz_QzGT_
-   ...             __import__('builtins').type(
+   ...   Flattener=__import__('builtins').type(
    ...               'Flattener',
    ...               (lambda * _: _)(),
    ...               __import__('builtins').dict(

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -3159,8 +3159,6 @@ Now look at what we can do.
 
    #> (-> (@ "abc") ([#0]) ([#::-1]))
    >>> # Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
-   ... # hissp.macros..QzMaybe_.Qz_QzGT_
    ... __import__('operator').itemgetter(
    ...   (__import__('builtins').globals()['slicer'][::-1]))(
    ...   __import__('operator').itemgetter(

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -882,13 +882,31 @@ Avoid writing anything in the Quotez style yourself.
 (This can confuse the demunger and risks collision with compiler-generated names like gensyms.)
 
 Docstrings use reStructuredText markup, like Python.
+
+Anaphoric or code string–injection macros are potential gotchas if you don't know this,
+so docstrings for them should include the word "Anaphoric" or "Injection" up front.
+Anaphoric macro docstrings should also state what the anaphors are,
+named in doubled backticks.
+
 Any docstring for something with a munged name
 should start with the demunged name in doubled backticks
-(this includes anything with a hyphen),
-followed by the pronunciation in single quotes,
-if it's not obvious from the identifier::
+(this includes anything with a hyphen).
 
-  "``&&`` 'and'. Like Python's ``and`` operator, but for any number of arguments."
+.. code-block:: Lissp
+
+   "``the#`` Anaphoric. Let ``the`` be a fresh `types.SimpleNamespace`
+   in a lexical scope surrounding ``e``.
+   "
+
+The demunged names should be followed by the pronunciation in single quotes,
+if it's not obvious from the identifier.
+
+.. code-block:: Lissp
+
+   "``&&`` 'and'. Like Python's ``and`` operator, but for any number of arguments."
+
+This way, all three name versions (munged, demunged, and pronounced)
+will appear in generated docs.
 
 Method Syntax vs Attribute Calls
 --------------------------------

--- a/src/hissp/__init__.py
+++ b/src/hissp/__init__.py
@@ -31,11 +31,14 @@ See the GitHub project for complete documentation and tests.
 https://github.com/gilch/hissp
 
 ``__init__.py`` imports several utilities for convenience, including
-`hissp.compiler.readerless`, `hissp.munger.demunge`,
-`hissp.reader.transpile`, and `hissp.repl.interact`,
-as well as the `hissp.macros._macro_` namespace,
-making all of the bundled macros available with the shorter
-``hissp.._macro_`` qualifier.
+
+* `hissp.compiler.readerless`,
+* `hissp.munger.demunge`,
+* `hissp.reader.transpile`, and
+* `hissp.repl.interact`,
+
+as well as the `hissp.macros._macro_` namespace, making all the bundled
+macros available with the shorter ``hissp.._macro_`` qualifier.
 """
 from hissp.compiler import readerless
 from hissp.munger import demunge

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -447,11 +447,14 @@ _#<<#
   Converts a pipeline to function calls by recursively threading
   expressions as the first argument of the next form.
   E.g. ``(-> x (A b) (C d e))`` is ``(C (A x b) d e)``
-  Makes chained method calls easier to read.
+  Non-tuple ``forms`` (typically function identifiers) will be wrapped
+  in a tuple. Makes chained method calls easier to read.
 
   See also: `->><Qz_QzGT_QzGT_>`, `@#<QzAT_QzHASH_>`, `get#<getQzHASH_>`.
   "
-  (functools..reduce XY#.#"(Y[0],X,*Y[1:],)" forms expr))
+  (functools..reduce XY#.#"(Y[0],X,*Y[1:],)"
+                     (map X#.#"X if type(X) is tuple else (X,)" forms)
+                     expr))
 
 (defmacro ->> (expr : :* forms)
   "``->>`` 'Thread-last'.
@@ -462,10 +465,13 @@ _#<<#
   Can replace partial application in some cases.
   Also works inside a ``->`` pipeline.
   E.g. ``(-> x (A a) (->> B b) (C c))`` is ``(C (B b (A x a)) c)``.
+  Non-tuple ``forms`` will be wrapped in a tuple.
 
   See also: `-><Qz_QzGT_>`.
   "
-  (functools..reduce XY#`(,@Y ,X) forms expr))
+  (functools..reduce XY#`(,@Y ,X)
+                     (map X#.#"X if type(X) is tuple else (X,)" forms)
+                     expr))
 
 ;; TODO: implement other arrange macros?
 
@@ -625,11 +631,11 @@ _#<<#
 (defmacro b\# (raw)
   "``b#`` `bytes` literal reader macro"
   (-> raw
-      (ast..literal_eval)
+      ast..literal_eval
       (.replace "'" "\'")
       (.replace #"\n" "\n")
       (->> (.format "b'{}'"))
-      (ast..literal_eval)))
+      ast..literal_eval))
 
 (defmacro en\# (f)
   <<#

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -552,7 +552,7 @@ _#<<#
 
   Returns the value of the final loop.
 
-  See also: `any*map<anyQzSTAR_map>`, ``Ensue`` from `prelude`.
+  See also: `any*map<anyQzSTAR_map>`, `Ensue`_.
   "
   `(let ($#stack (@ () None ,inits))
      (let (,'recur-from $#stack.append)
@@ -605,7 +605,7 @@ _#<<#
 (defmacro throw (exception)
   "Raise an exception.
 
-  See also: `throw-from<throwQz_from>`, ``engarde`` from `prelude`.
+  See also: `throw-from<throwQz_from>`, `engarde`_.
   "
   `(throw* ,exception))
 
@@ -761,20 +761,6 @@ _#<<#
   Brings Hissp up to a minimal standard of usability without adding any
   dependencies in the compiled output.
 
-  Imports `functools.partial` and `functools.reduce`.
-  Star imports from `itertools` and `operator`.
-
-  Defines ``engarde``, which calls a function for you, handling any
-  targeted exceptions with the given handler.
-
-  Defines ``enter``, which calls a function with a context manager.
-
-  Defines ``Ensue`` for trampolined continuation generators.
-
-  Adds the bundled macros, but only if available,
-  so its expansion does not require Hissp to be installed.
-  (This replaces ``_macro_`` if you already had one.)
-
   Mainly intended for single-file scripts that can't have dependencies,
   or similarly constrained environments (e.g. embedded, readerless).
   There, the first form should be ``(hissp.._macro_.prelude)``,
@@ -782,6 +768,58 @@ _#<<#
 
   Larger projects with access to functional and macro libraries need not
   use this prelude at all.
+
+  The prelude has several effects:
+
+  * Imports `functools.partial` and `functools.reduce`.
+    Star imports from `itertools` and `operator`.
+
+  .. _engarde:
+
+  * Defines ``engarde``, which calls a function with exception handler::
+
+     def engarde(xs,h,f,/,*a,**kw):
+      try:return f(*a,**kw)
+      except xs as e:return h(e)
+
+    ``engarde`` with handlers can stack above in a single form.
+
+    See `lissp_whirlwind_tour` (§16) for usage examples.
+
+  .. _enter:
+
+  * Defines ``enter``, which calls a function with context manager::
+
+     def enter(c,f,/,*a):
+      with c as C:return f(*a,C)
+
+    ``enter`` with context managers can stack above in a single form.
+
+    See `lissp_whirlwind_tour` (§18) for usage examples.
+
+  .. _Ensue:
+
+  * Defines the ``Ensue`` class for trampolined continuation generators.
+
+    ``Ensue`` takes a step function and returns a generator. The step
+    function recieves the previous Ensue step and must return the next
+    one to continue. Returning a different type raises a `StopIteration`
+    with that object. Set the ``Y`` attribute on the current step to
+    [Y]ield a value this step. Set the ``F`` attribute to a true value
+    to yield values [F]rom the ``Y`` iterable instead. Set the ``X``
+    attribute to an e[X]ception class or tuple to catch any targeted
+    exceptions on the next step. Each step keeps a ``sent`` attribute,
+    which is the value sent to the generator this step, or the exception
+    caught this step instead.
+
+    See `lissp_whirlwind_tour` (§§17–18) for usage examples.
+
+    See also: `types.coroutine`, `collections.abc.Generator`.
+
+  * Adds the bundled macros, but only if available
+    (macros are typically only used at compile time),
+    so its compiled expansion does not require Hissp to be installed.
+    (This replaces ``_macro_`` if you already had one.)
 
   The REPL has the bundled macros loaded by default, but not the prelude.
   Invoke ``(prelude)`` to get the rest.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -223,7 +223,7 @@ _#<<#
 
   Key-value pairs are implied in the body.
 
-  See also: `type`
+  See also: `type`, `@@#<QzAT_QzAT_QzHASH_>`.
   "
   `(define ,name
        (type ',name (,hissp.reader..ENTUPLE ,@bases)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -262,7 +262,7 @@ _#<<#
     `(progn ,@body)))
 
 (defmacro the\# e
-  "``the#`` Anaphoric. Let ``the`` be a fresh `types.SimpleNamespace`
+  "``the#`` Anaphoric. `let` ``the`` be a fresh `types.SimpleNamespace`
   in a lexical scope surrounding e.
   "
   `(let (,'the (types..SimpleNamespace))
@@ -585,8 +585,8 @@ _#<<#
   "``throw*`` Creates a closed generator and calls its throw method.
 
   Despite PEP 3109, .throw still seems to accept multiple arguments.
-  You should basically never use more than one, except when implementing
-  your own throw method overrides. Otherwise, use `throw` instead.
+  Avoid using this form except when implementing throw method overrides.
+  Prefer `throw` instead.
   "
   `(.throw (let ($#gen (traceback..walk_tb None))
              (.close $#gen)
@@ -631,7 +631,7 @@ _#<<#
 ;;; reader
 
 (defmacro b\# (raw)
-  "``b#`` bytes literal reader macro"
+  "``b#`` `bytes` literal reader macro"
   (-> raw
       (ast..literal_eval)
       (.replace "'" "\'")
@@ -848,12 +848,12 @@ except ModuleNotFoundError:pass"
        $#val)))
 
 (defmacro ensure (e predicate : :* args)
-  "Anaphoric. Raises AssertionError unless (-> e predicate).
+  "Anaphoric. Raises `AssertionError` `unless` (-> e predicate).
 
   Additional arguments are evaluated in a context where ``it`` refers
-  to the result of e. These (if any) are passed to the AssertionError.
+  to the result of e. These (if any) are passed to the `AssertionError`.
 
-  Compilation is simply e when __debug__ is off.
+  Expansion is simply ``e`` when `__debug__` is off.
   "
   (if-else __debug__
     `(let (,'it ,e)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -612,6 +612,8 @@ _#<<#
   ``:*`` unpacks the next argument.
   Mnemonic: @rray list.
   "
+  (when (&& xs (op#eq :* (get#-1 xs)))
+     (throw (SyntaxError "trailing :*")))
   (let (ixs (iter xs))
     `(en#list : ,@chain#(map X#(if-else (op#eq X ":*")
                                  `(,X ,(next ixs))
@@ -624,6 +626,8 @@ _#<<#
   ``:*`` unpacks the next argument.
   Mnemonic: Hash (#) set.
   "
+  (when (&& xs (op#eq :* (get#-1 xs)))
+     (throw (SyntaxError "trailing :*")))
   (let (ixs (iter xs))
     `(en#set : ,@chain#(map X#(if-else (op#eq X ":*")
                                 `(,X ,(next ixs))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -470,10 +470,7 @@ _#<<#
 
   See also: `-><Qz_QzGT_>`.
   "
-  (if-else forms
-    `(->> (,@(get#0 forms) ,expr)
-          ,@(get#(slice 1 None) forms))
-    expr))
+  (functools..reduce XY#`(,@Y ,X) forms expr))
 
 ;; TODO: implement other arrange macros?
 

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -877,6 +877,25 @@ except ModuleNotFoundError:pass"
   ``definition`` form must assign a global identified by its first arg.
   (E.g. `define` and `deftype` are compatible.) Expands to a `define`,
   meaning decorators can stack.
+
+  .. code-block:: REPL
+
+     #> @@#!str.upper
+     #..(define foo 'foo)
+     >>> # hissp.macros.._macro_.define
+     ... __import__('builtins').globals().update(
+     ...   foo=# hissp.macros.._macro_.progn
+     ...       (lambda :(
+     ...         # define
+     ...         __import__('builtins').globals().update(
+     ...           foo='foo'),
+     ...         str.upper(
+     ...           foo))[-1])())
+
+     #> foo
+     >>> foo
+     'FOO'
+
   "
   (let (name (get#1 definition))
     `(define ,name (progn ,definition (,function ,name)))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -451,12 +451,7 @@ _#<<#
 
   See also: `->><Qz_QzGT_QzGT_>`, `@#<QzAT_QzHASH_>`, `get#<getQzHASH_>`.
   "
-  (if-else forms
-    `(-> (,(get#0 (get#0 forms))
-          ,expr
-          ,@(get#(slice 1 None) (get#0 forms)))
-         ,@(get#(slice 1 None) forms))
-    expr))
+  (functools..reduce XY#.#"(Y[0],X,*Y[1:],)" forms expr))
 
 (defmacro ->> (expr : :* forms)
   "``->>`` 'Thread-last'.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -218,26 +218,16 @@ _#<<#
   `(unless (operator..contains (globals) ',name)
      (define ,name ,value)))
 
-(defmacro deftype@ (decorators name bases : :* body)
-  "``deftype@`` Defines a decorated type (class) in the current module.
-
-  Key-value pairs are implied in the body.
-
-  See also: `type`, `deftype`.
-  "
-  `(define ,name
-     (-> (type ',name (,hissp.reader..ENTUPLE ,@bases)
-               (dict : ,@body))
-         ,@(reversed (list (zip decorators))))))
-
 (defmacro deftype (name bases : :* body)
   "Defines a type (class) in the current module.
 
   Key-value pairs are implied in the body.
 
-  See also: `type`, `deftype@<deftypeQzAT_>`.
+  See also: `type`
   "
-  (.deftype@ _macro_ () name bases : :* body))
+  `(define ,name
+       (type ',name (,hissp.reader..ENTUPLE ,@bases)
+             (dict : ,@body))))
 
 ;;; locals
 
@@ -391,6 +381,7 @@ _#<<#
   "``zap!`` 'zapbang' Augmented item assignment operator.
 
   The current item value becomes the first argument.
+  Returns the value.
   Mnemonic: zap !tem.
 
   See also: `set!<setQzBANG_>`, `zap@<zapQzAT_>`.
@@ -415,6 +406,7 @@ _#<<#
   "``zap@`` 'zapat' Augmented attribute assignment operator.
 
   The current attribute value becomes the first argument.
+  Returns the value.
   Mnemonic: zap @tribute.
 
   See also: `set@<setQzAT_>`, `zap!<zapQzBANG_>`.
@@ -878,3 +870,16 @@ except ModuleNotFoundError:pass"
          (throw (AssertionError ,@args)))
        ,'it)
     e))
+
+(defmacro decor\# (definition : :* decorators)
+  "``decor#`` Applies `Extra`s to the defined name and reassigns it.
+
+  ``decorators`` apply inside-out. `definition` must assign a global
+  identified by its first argument.
+  "
+  `(progn
+     ,definition
+     (define ,(get#1 definition)
+       ,(functools..reduce XY#`(,Y ,X)
+                           (reversed decorators)
+                           (get#1 definition)))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -2,30 +2,17 @@
 ;; SPDX-License-Identifier: Apache-2.0
 "Hissp's bundled macros.
 
-The bundled macros are just enough to test and demonstrate Hissp's macro
-system; they are not intended to be a standard library for general use,
-but may suffice for small projects.
+To help keep macro definitions and expansions manageable in complexity,
+these macros lack some of the extra features their equivalents have in
+Python or in other Lisps. These are not intended to be a standard
+library for general use, but do bring Hissp up to a basic standard of
+utility without adding dependencies, which may suffice in some cases.
 
-As a convenience, they are automatically made available unqualified in
-the Lissp REPL, but this does not apply to modules. (A Hissp module with
-better alternatives need not use the bundled macros at all.) In modules,
-either use the fully-qualified names, or start with the `prelude` macro.
-
-You can abbreviate qualifiers with the `alias` macro:
-
-.. code-block:: Lissp
-
-  (hissp.._macro_.alias b/ hissp.._macro_.)
-  ;; Now the same as (hissp.._macro_.define foo 2).
-  (b/#define foo 2)
-
-The bundled macros are deliberately restricted in design.
-
-They have NO DEPENDENCIES in their expansions; they use only the
-standard library with no extra helper functions. This means that all
-helper code must be inlined, resulting in larger expansions than might
-otherwise be necessary. But because macros expand before run time, the
-compiled code does not require Hissp to be installed to work.
+Because of certain deliberate restrictions in design, there are no
+dependencies in their expansions either, meaning compiled Hissp code
+utilizing the bundled macros need not have Hissp installed to work, only
+the Python standard library. All helper code must therefore be inlined,
+resulting in larger expansions than might otherwise be necessary.
 
 They also have no prerequisite initialization, beyond what is available
 in a standard Python module. For example, a ``_macro_`` namespace need
@@ -33,16 +20,17 @@ not be available for ``defmacro``. It's smart enough to check for the
 presence of ``_macro_`` (at compile time) in its expansion context, and
 inline the initialization code when required.
 
-With the exception of `prelude` (which uses `exec`), and
-`subscript <QzLSQB_QzHASH_>`, which is not used internally, they also
-eschew any expansions to Python code, relying only on the built-in
-special forms ``quote`` and ``lambda``, which makes their expansions
-compatible with advanced rewriting macros that process the Hissp
-expansions of other macros.
+As a convenience, the bundled macros are automatically made available
+unqualified in the Lissp REPL, but this does not apply to modules. A
+Hissp module with better alternatives need not use the bundled macros at
+all.
 
-To help keep macro definitions and expansions manageable in complexity,
-these macros lack some of the extra features their equivalents
-have in Python or in other Lisps.
+With the exception of `prelude` (which uses `exec`), and `subscript
+<QzLSQB_QzHASH_>` (``[#``), which is not used internally, they also
+eschew any expansions to non-atomic Python code strings, relying only on
+the built-in special forms ``quote`` and ``lambda``, which makes their
+expansions compatible with advanced rewriting macros that process the
+Hissp expansions of other macros.
 "
 
 _#" This module is not necessarily a good example of how you should

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -679,11 +679,29 @@ _#<<#
 ;;; collection
 
 (defmacro @ (: :* xs)
-  "``@`` 'list of'
-
-  ``:*`` unpacks the next argument.
-  Mnemonic: @rray list.
-  "
+  <<#
+  !;``@`` 'list of' Mnemonic: @rray list.
+  !;
+  !;Creates the `list` from each expresssion's result.
+  !;A ``:*`` unpacks the next argument.
+  !;
+  !;.. code-block:: REPL
+  !;
+  !;   #> (@ :* "AB" (math..sqrt 9) :* "XY" 2 1)
+  !;   >>> # QzAT_
+  !;   ... (lambda *_QzNo55_xs:
+  !;   ...   __import__('builtins').list(
+  !;   ...     _QzNo55_xs))(
+  !;   ...   *('AB'),
+  !;   ...   __import__('math').sqrt(
+  !;   ...     (9)),
+  !;   ...   *('XY'),
+  !;   ...   (2),
+  !;   ...   (1))
+  !;   ['A', 'B', 3.0, 'X', 'Y', 2, 1]
+  !;
+  !;See also: `#<QzHASH_>`, `%<QzPCENT_>`.
+  #"\n"
   (when (&& xs (op#eq :* (get#-1 xs)))
      (throw (SyntaxError "trailing :*")))
   (let (ixs (iter xs))
@@ -845,5 +863,20 @@ except ModuleNotFoundError:pass"
     e))
 
 (defmacro \[\# e
+  "``[#`` 'subscript' Injection. Python's subscription operator.
+
+  Creates a function from the Python expression ``e`` prepended with
+  the argument and a ``[``.
+
+  .. code-block:: Lissp
+
+     #> ([#1][::2] '(foo bar))
+     >>> (lambda _QzNo76_G:(_QzNo76_G[1][::2]))(
+     ...   ('foo',
+     ...    'bar',))
+     'br'
+
+  See also: `get#<getQzHASH_>`, `-><Qz_QzGT_>`, `slice`.
+  "
   "``subscript`` Injection. Python's subscription operator."
   `(lambda ($#G) ,(.format "({}[{})" '$#G (hissp..demunge e))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -871,15 +871,12 @@ except ModuleNotFoundError:pass"
        ,'it)
     e))
 
-(defmacro decor\# (definition : :* decorators)
-  "``decor#`` Applies `Extra`s to the defined name and reassigns it.
+(defmacro @@\# (definition function)
+  "``@@#`` 'decorator' applies ``function`` to defined name & reassigns.
 
-  ``decorators`` apply inside-out. `definition` must assign a global
-  identified by its first argument.
+  ``definition`` form must assign a global identified by its first arg.
+  (E.g. `define` and `deftype` are compatible.) Expands to a `define`,
+  meaning decorators can stack.
   "
-  `(progn
-     ,definition
-     (define ,(get#1 definition)
-       ,(functools..reduce XY#`(,Y ,X)
-                           (reversed decorators)
-                           (get#1 definition)))))
+  (let (name (get#1 definition))
+    `(define ,name (progn ,definition (,function ,name)))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -26,7 +26,7 @@ Hissp module with better alternatives need not use the bundled macros at
 all.
 
 With the exception of `prelude` (which uses `exec`), and `subscript
-<QzLSQB_QzHASH_>` (``[#``), which is not used internally, they also
+<QzLSQB_QzHASH_>` (``[#``), which is not used in expansions, they also
 eschew any expansions to non-atomic Python code strings, relying only on
 the built-in special forms ``quote`` and ``lambda``, which makes their
 expansions compatible with advanced rewriting macros that process the
@@ -356,6 +356,25 @@ _#<<#
   "
   `(op#itemgetter ,e))
 
+(defmacro \[\# e
+  "``[#`` 'subscript' Injection. Python's subscription operator.
+
+  Creates a function from the Python expression ``e`` prepended with
+  the argument and a ``[``.
+
+  .. code-block:: Lissp
+
+     #> ([#1][::2] '(foo bar))
+     >>> (lambda _QzNo76_G:(_QzNo76_G[1][::2]))(
+     ...   ('foo',
+     ...    'bar',))
+     'br'
+
+  See also: `get#<getQzHASH_>`, `-><Qz_QzGT_>`, `slice`.
+  "
+  "``subscript`` Injection. Python's subscription operator."
+  `(lambda ($#G) ,(.format "({}[{})" '$#G (hissp..demunge e))))
+
 ;;; configuration
 
 (defmacro set! (coll key val)
@@ -435,7 +454,7 @@ _#<<#
     `((lambda (: ,$self ,self)
         ,@(map X#`(,(get#0 X)
                    ,$self
-                   ,@(get#(slice 1 None) X))
+                   ,@([#1:] X))
                invocations)
         ,$self))))
 
@@ -504,7 +523,7 @@ _#<<#
     `(if-else ,(get#0 pairs)
               ,(get#1 pairs)
               ;; Here's the recursive part.
-              (cond ,@(get#(slice 2 None) pairs)))))
+              (cond ,@([#2:] pairs)))))
 
 (defmacro any-map (variable xs : :* body)
   "``any-map``
@@ -562,7 +581,7 @@ _#<<#
         (op#eq (len exprs) 1) (get#0 exprs)
         :else `(let ($#G ,(get#0 exprs))
                  (if-else $#G
-                          (&& ,@(get#(slice 1 None) exprs))
+                          (&& ,@([#1:] exprs))
                           $#G))))
 
 (defmacro || (: first () :* rest)
@@ -811,8 +830,8 @@ except ModuleNotFoundError:pass"
   "
   (when (op#mod (len pairs) 2)
     (throw (TypeError "Incomplete pair")))
-  (let (kss (get#(slice -2 None -2) pairs)
-        ts (get#(slice None None -2) pairs))
+  (let (kss ([#-2::-2] pairs)
+        ts ([#::-2] pairs))
     `((op#getitem (@ ,@(map X#`&#,X ts) &#,default)
                   (.get ,(dict chain#(i#starmap (lambda (i ks)
                                                   (map X#(@ X i) ks))
@@ -859,22 +878,3 @@ except ModuleNotFoundError:pass"
          (throw (AssertionError ,@args)))
        ,'it)
     e))
-
-(defmacro \[\# e
-  "``[#`` 'subscript' Injection. Python's subscription operator.
-
-  Creates a function from the Python expression ``e`` prepended with
-  the argument and a ``[``.
-
-  .. code-block:: Lissp
-
-     #> ([#1][::2] '(foo bar))
-     >>> (lambda _QzNo76_G:(_QzNo76_G[1][::2]))(
-     ...   ('foo',
-     ...    'bar',))
-     'br'
-
-  See also: `get#<getQzHASH_>`, `-><Qz_QzGT_>`, `slice`.
-  "
-  "``subscript`` Injection. Python's subscription operator."
-  `(lambda ($#G) ,(.format "({}[{})" '$#G (hissp..demunge e))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -76,6 +76,8 @@ judicious use can improve performance and maintainability.
   "``if-else`` Basic ternary branching construct.
 
   Like Python's conditional expressions, the 'else' clause is required.
+
+  See also: `when`, `cond`.
   "
   `((lambda (,'test : :* ,'then-else)
       ((operator..getitem ,'then-else (operator..not_ ,'test))))
@@ -86,6 +88,8 @@ judicious use can improve performance and maintainability.
 (defmacro progn (: :* body)
   "Evaluates each body expression in sequence (for side effects),
   resulting in the value of the last (or ``()`` if empty).
+
+  See also: `prog1`, `doto`.
   "
   ;; TODO: consider flattening nested progns
   `((lambda :
@@ -96,6 +100,8 @@ judicious use can improve performance and maintainability.
   evaluates each expression in sequence for side effects,
   resulting in the value of the last.
   Otherwise, skips them and returns ``()``.
+
+  See also: `if-else<ifQz_else>`, `unless`.
   "
   `(if-else ,condition (progn ,@body) ()))
 
@@ -104,11 +110,18 @@ judicious use can improve performance and maintainability.
   evaluates each expression in sequence for side effects,
   resulting in the value of the last.
   Otherwise, skips them and returns ``()``.
+
+  See also: `when`.
   "
   `(if-else ,condition () (progn ,@body)))
 
 (defmacro let (pairs : :* body)
-  "Creates local variables. Pairs are implied. Locals are not in scope until the body."
+  "Creates local variables. Pairs are implied by position.
+
+  Locals are not in scope until the body.
+
+  See also: `let-from<letQz_from>`, `the#<theQzHASH_>`.
+  "
   `((lambda (: ,@pairs)
       ,@body)))
 
@@ -185,16 +198,23 @@ _#<<#
  !;   >>> 'C:\\bin;C:\\Users\\ME\\Documents;C:\\Users\\ME\\Pictures'
  !;   'C:\\bin;C:\\Users\\ME\\Documents;C:\\Users\\ME\\Pictures'
  !;
+ !;See also: `str.join`, `Extra`.
  #"\n")
 
 (defmacro define (name value)
-  "Assigns a global the value in the current module."
+  "Assigns a global the value in the current module.
+
+  See also: `globals`, `dict.update`, `defonce`.
+  "
   `(.update (globals)
             : ,name
             ,value))
 
 (defmacro defonce (name value)
-  "Assigns a global the value in the current module, unless it exists."
+  "Assigns a global the value in the current module, unless it exists.
+
+  See also: `define`.
+  "
   `(unless (operator..contains (globals) ',name)
      (define ,name ,value)))
 
@@ -202,6 +222,8 @@ _#<<#
   "``deftype@`` Defines a decorated type (class) in the current module.
 
   Key-value pairs are implied in the body.
+
+  See also: `type`, `deftype`.
   "
   `(define ,name
      (-> (type ',name (,hissp.reader..ENTUPLE ,@bases)
@@ -212,6 +234,8 @@ _#<<#
   "Defines a type (class) in the current module.
 
   Key-value pairs are implied in the body.
+
+  See also: `type`, `deftype@<deftypeQzAT_>`.
   "
   (.deftype@ _macro_ () name bases : :* body))
 
@@ -220,7 +244,10 @@ _#<<#
 ;; see also from bootstrap: let
 
 (defmacro let-from (syms itr : :* body)
-  "``let-from`` Create listed locals from iterable."
+  "``let-from`` Create listed locals from iterable.
+
+  See also: `let`, `let*from<letQzSTAR_from>`.
+  "
   `((lambda ,syms
       ,@body)
     : :* ,itr))
@@ -244,23 +271,38 @@ _#<<#
 ;;; abbreviations
 
 (defmacro &\# e
-  "``&#`` 'thunk' Make e an anonymous function with no parameters."
+  "``&#`` 'thunk' Make ``e`` an anonymous function with no parameters.
+
+  See also: `X#<XQzHASH_>`.
+  "
   `(lambda : ,e))
 
 (defmacro X\# e
-  "``X#`` Anaphoric. Make e an anonymous function with paramter X."
+  "``X#`` Anaphoric. Make ``e`` an anonymous function with paramter X.
+
+  See also: `en#<enQzHASH_>`, `&#<QzET_QzHASH_>`, `XY#<XYQzHASH_>`.
+  "
   `(lambda ,'X ,e))
 
 (defmacro XY\# e
-  "``XY#`` Anaphoric. Make e an anonymous function with paramters X Y."
+  "``XY#`` Anaphoric. Make ``e`` an anonymous function with paramters X Y.
+
+  See also: `X#<XQzHASH_>`, `XYZ#<XYZQzHASH_>`.
+  "
   `(lambda ,'XY ,e))
 
 (defmacro XYZ\# e
-  "``XYZ#`` Anaphoric. Make e an anonymous function with paramters X Y Z."
+  "``XYZ#`` Anaphoric. Make ``e`` an anonymous function with paramters X Y Z.
+
+  See also: `XY#<XYQzHASH_>`, `XYZW#<XYZWQzHASH_>`.
+  "
   `(lambda ,'XYZ ,e))
 
 (defmacro XYZW\# e
-  "``XYZW#`` Anaphoric. Make e an anonymous function with paramters X Y Z W."
+  "``XYZW#`` Anaphoric. Make ``e`` an anonymous function with paramters X Y Z W.
+
+  See also: `XYZ#<XYZQzHASH_>`, `en#<enQzHASH_>`, `X#<XQzHASH_>`.
+  "
   `(lambda ,'XYZW ,e))
 
 (defmacro alias (alias module)
@@ -300,11 +342,18 @@ _#<<#
   `(i#chain.from_iterable ,itr))
 
 (defmacro @\# (symbol)
-  "``@#`` 'attrgetter-' Makes an attr getter function from the symbol."
+  "``@#`` 'attrgetter-' Makes an `operator.attrgetter` from ``symbol``.
+
+  See also: `get#<getQzHASH_>`, `getattr`, `set@<setQzAT_>`.
+  "
   `(op#attrgetter ',symbol))
 
 (defmacro get\# e
-  "``get#`` 'itemgetter-' Makes an item getter function from e."
+  "``get#`` 'itemgetter-' Makes an `operator.itemgetter` function from ``e``.
+
+  See also: `@#<QzAT_QzHASH_>`, `operator.getitem`, `[#<QzLSQB_QzHASH_>`,
+  `set!<setQzBANG_>`.
+  "
   `(op#itemgetter ,e))
 
 ;;; configuration
@@ -312,6 +361,8 @@ _#<<#
 (defmacro set! (coll key val)
   "``set!`` 'setbang' Assigns an item, returns the value.
   Mnemonic: set !tem.
+
+  See also: `operator.setitem`, `operator.delitem`, `zap!<zapQzBANG_>`.
   "
   `(let ($#val ,val)
      (op#setitem ,coll ,key $#val)
@@ -322,6 +373,8 @@ _#<<#
 
   The current item value becomes the first argument.
   Mnemonic: zap !tem.
+
+  See also: `set!<setQzBANG_>`, `zap@<zapQzAT_>`.
   "
   `(let ($#coll ,coll
          $#key ,key)
@@ -331,6 +384,8 @@ _#<<#
 (defmacro set@ (name val)
   "``set@`` 'setat' Assigns an attribute, returns the value.
   Mnemonic: set @tribute.
+
+  See also: `attach`, `delattr`, `zap@<zapQzAT_>`.
   "
   (let-from (ns _ attr) (.rpartition name ".")
     `(let ($#val ,val)
@@ -342,6 +397,8 @@ _#<<#
 
   The current attribute value becomes the first argument.
   Mnemonic: zap @tribute.
+
+  See also: `set@<setQzAT_>`, `zap!<zapQzBANG_>`.
   "
   `(set@ ,name (,op ,name ,@args)))
 
@@ -352,6 +409,8 @@ _#<<#
   and use that as the attribute name.
   Names after the ``:`` are identifier-value pairs.
   Returns the target.
+
+  See also: `setattr`, `set@<setQzAT_>`, `locals`.
   "
   (let (iargs (iter args)
         $target `$#target)
@@ -369,6 +428,8 @@ _#<<#
 
   Evaluates the given ``self``, then injects it as the first argument to
   a sequence of invocations. Returns ``self``.
+
+  See also: `attach`, `progn`.
   "
   (let ($self `$#self)
     `((lambda (: ,$self ,self)
@@ -387,6 +448,8 @@ _#<<#
   expressions as the first argument of the next form.
   E.g. ``(-> x (A b) (C d e))`` is ``(C (A x b) d e)``
   Makes chained method calls easier to read.
+
+  See also: `->><Qz_QzGT_QzGT_>`, `@#<QzAT_QzHASH_>`, `get#<getQzHASH_>`.
   "
   (if-else forms
     `(-> (,(get#0 (get#0 forms))
@@ -404,6 +467,8 @@ _#<<#
   Can replace partial application in some cases.
   Also works inside a ``->`` pipeline.
   E.g. ``(-> x (A a) (->> B b) (C c))`` is ``(C (B b (A x a)) c)``.
+
+  See also: `-><Qz_QzGT_>`.
   "
   (if-else forms
     `(->> (,@(get#0 forms) ,expr)
@@ -435,6 +500,7 @@ _#<<#
   !;       (op#eq x 0) (print "zero")
   !;       :else (print "not a number"))
   !;
+  !;See also: `if-else<ifQz_else>`, `case`.
   #"\n"
   (when pairs
     `(if-else ,(get#0 pairs)
@@ -447,6 +513,8 @@ _#<<#
   Bind the variable and evaluate the body for each x from xs
   until any result is true (and return ``True``), or until xs is
   exhausted (and return ``False``).
+
+  See also: `any*map<anyQzSTAR_map>`.
   "
   `(any (map (lambda (,variable)
                ,@body)
@@ -457,6 +525,8 @@ _#<<#
   Bind each x to a variable and evaluate the body for each xs from xss
   until any result is true (and return ``True``), or until xss is
   exhausted (and return ``False``).
+
+  See also: `any-map<anyQz_map>`, `loop-from<loopQz_from>`.
   "
   `(any (i#starmap (lambda ,variables ,@body)
                    ,xss)))
@@ -472,6 +542,8 @@ _#<<#
   to the schedule. Call with None to abort any remaining schedule.
 
   Returns the value of the final loop.
+
+  See also: `any*map<anyQzSTAR_map>`, ``Ensue`` from `prelude`.
   "
   `(let ($#stack (@ () None ,inits))
      (let (,'recur-from $#stack.append)
@@ -485,6 +557,8 @@ _#<<#
   "``&&`` 'and'. Shortcutting logical AND.
   Returns the first false value, otherwise the last value.
   There is an implicit initial value of ``True``.
+
+  See also: `||<QzBAR_QzBAR_>`, `operator.not_`.
   "
   (cond (op#not_ exprs) True
         (op#eq (len exprs) 1) (get#0 exprs)
@@ -497,6 +571,8 @@ _#<<#
   "``||`` 'or'. Shortcutting logical OR.
   Returns the first true value, otherwise the last value.
   There is an implicit initial value of ``()``.
+
+  See also: `&&<QzET_QzET_>`, `bool`.
   "
   (if-else rest
            `(let ($#first ,first)
@@ -518,11 +594,17 @@ _#<<#
            ,@exception))
 
 (defmacro throw (exception)
-  "Raise an exception."
+  "Raise an exception.
+
+  See also: `throw-from<throwQz_from>`, ``engarde`` from `prelude`.
+  "
   `(throw* ,exception))
 
 (defmacro throw-from (exception cause)
-  "Raise an exception with a cause, which can be None."
+  "Raise an exception with a cause, which can be None.
+
+  See also: `throw`, `throw*<throwQzSTAR_>`.
+  "
   `(throw* (let ($#G (lambda ($#x)
                        (if-else (&& (isinstance $#x type)
                                     (issubclass $#x BaseException))
@@ -536,6 +618,8 @@ _#<<#
 (defmacro prog1 (expr1 : :* body)
   "Evaluates each expression in sequence (for side effects),
   resulting in the value of the first.
+
+  See also: `progn`.
   "
   `(let ($#value1 ,expr1)
      ,@body
@@ -609,10 +693,12 @@ _#<<#
                              ixs))))
 
 (defmacro # (: :* xs)
-  "``#`` 'set of'
+  "``#`` 'set of' Mnemonic: Hash (#) set.
 
-  ``:*`` unpacks the next argument.
-  Mnemonic: Hash (#) set.
+  Creates the `set` from each expression's result.
+  A ``:*`` unpacks the next argument.
+
+  See also: `@<QzAT_>`, `%<QzPCENT_>`.
   "
   (when (&& xs (op#eq :* (get#-1 xs)))
      (throw (SyntaxError "trailing :*")))
@@ -623,11 +709,12 @@ _#<<#
                             ixs))))
 
 (defmacro % (: :* kvs)
-  "``%`` 'dict of'.
+  "``%`` 'dict of'. Mnemonic: `dict` of pairs (%).
 
-  Key-value pairs are implied.
-  ``:**`` unpacks mappings.
-  Mnemonic: dict of pairs (%).
+  Key-value pairs are implied by position.
+  A ``:**`` mapping-unpacks the next argument.
+
+  See also: `@<QzAT_>`, `#<QzHASH_>`.
   "
   (when (op#mod (len kvs) 2)
     (throw (TypeError "extra key without value")))
@@ -703,6 +790,8 @@ except ModuleNotFoundError:pass"
   Must switch on a hashable key.
   The default case is first and required.
   The remainder are implicitly paired.
+
+  See also: `cond`.
   "
   (when (op#mod (len pairs) 2)
     (throw (TypeError "Incomplete pair")))

--- a/tests/test_macros.lissp
+++ b/tests/test_macros.lissp
@@ -200,7 +200,7 @@
 
   test_->
   (lambda (self)
-    (self.assertEqual (*#-> "-x-" (.replace "x" "y") (.strip "-") (.upper))
+    (self.assertEqual (*#-> "-x-" (.replace "x" "y") (.strip "-") .upper)
                       "Y"))
 
   test_->>
@@ -209,7 +209,7 @@
                              (map (lambda (x) (operator..mul x x)))
                              (filter (lambda (x) ; even?
                                        (operator..eq 0 (operator..mod x 2))))
-                             (list))
+                             list)
                       (enlist 0 4)))
 
   test_prelude


### PR DESCRIPTION
More to do, but this branch has probably run on long enough.

Lots of cross-references in macros and various other documentation improvements.

Notable non-documentation changes include

* -> / ->> simplification and enhancement. No longer recursive, so the compiler won't insert as many comments. The wrapping `()` is now implied for non-tuple arguments, like Clojure. The implementations are not really any longer, despite the extra feature, due to simplifications. This did include some judicious use of injections (which are an implementation detail that don't appear in the expansions).
* Replace `deftype@` with `@@#`, a decorator reader macro. Turns out reader macros are easily powerful enough to implement the decorator sugar with a tag and extra, at least for the global def- forms, including `define` functions. Methods are a different story, but no worse than before.
* Detect trailing `:*` in `(@)` and `(#)` forms. This is slightly too strict as e.g. `(@ :* :*)` now errors, but that had a reasonable interpretation of `[':', '*']` before, but this is more likely to be a mistake than useful behavior, and there are other aliases that work fine (just quote it). Adding an exception for these cases didn't seem worth it.
