### PR TITLE
Parameters trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ extending that ability to custom tuple forms.
 ...         return ('branch',condition,('thunk',consequent,),('thunk',alternate,),)
 ...
 >>> expansion = readerless(
-...     ('if_else','0==1',  # Macro form, not a runtime call.
+...     ('if_else','0==1',  # Macro form, not a run-time call.
 ...       ('print',('quote','yes',),),  # Side effect not evaluated!
 ...       ('print',('quote','no',),),),
 ...     globals())  # Pass in globals for _macro_.

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -284,9 +284,10 @@ def test_compile_error():
         "> #> ", "< (lambda :x)",
         "! >>> # CompileError\n",
         "! \n",
-        "! (>   >  > >>('lambda', ':x')<< <  <   <)\n",
-        "! # Compiler.function() CompileError:\n",
+        "! (lambda (>   >  > >>':x'<< <  <   <)\n",
+        "! # Compiler.parameters() CompileError:\n",
         "! #  Incomplete pair.\n",
+        "! :())\n",
         "> #> ",
     )  # fmt: skip
 


### PR DESCRIPTION
`CompileError` trace now points to the parameters list in a lambda form (when the error is there) instead of the whole lambda form, which can be confusing when the body is long. This is how I intended it to work in the first place, but I did have to change the implementation of the `.parameters()` method a little to make it work. I'm still not totally sure if it's possible to hit a trace in every method that has one.