### PR TITLE
Docs pass5

### DIFF
--- a/docs/_templates/base.html
+++ b/docs/_templates/base.html
@@ -39,22 +39,22 @@ SPDX-License-Identifier: Apache-2.0
 </style>
 <style type="text/css">
 /* Dark-Theme Contrast Tweaks for Monokai Theme */
-body[data-theme="dark"] .highlight .gh {
-color: hsl(212deg, 30%, 96%);
-font-weight: bold;
+body:not([data-theme="light"]) .highlight .gh {
+  color: hsl(212deg, 30%, 96%);
+  font-weight: bold;
 }
-body[data-theme="dark"] .highlight .gu {
-color: hsl(212deg, 30%, 96%);
-font-style: italic;
+body:not([data-theme="light"]) .highlight .gu {
+  color: hsl(212deg, 30%, 96%);
+  font-style: italic;
 }
-body[data-theme="dark"] .highlight .c {
+body:not([data-theme="light"]) .highlight .c {
   color: hsl(212deg, 9%, 58%)
 }
-body[data-theme="dark"] .highlight .c1 {
-color: hsl(212deg, 9%, 58%)
+body:not([data-theme="light"]) .highlight .c1 {
+  color: hsl(212deg, 9%, 58%)
 }
-body[data-theme="dark"] .highlight {
-background: #0d1117
+body:not([data-theme="light"]) .highlight {
+  background: #0d1117
 }
 </style>
 {% endblock %}

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2894,7 +2894,7 @@ Lissp Whirlwind Tour
    3.0
 
 
-   ;; You can nest them.
+   ;; You can stack them.
    #> (engarde Exception                                               ;The outer engarde
    #.. print
    #.. engarde ZeroDivisionError                                       ; calls the inner.
@@ -3054,7 +3054,7 @@ Lissp Whirlwind Tour
    [1, 2, 3, 4, 5]
 
 
-   ;; Set F to yield From.
+   ;; Set F to yield-From mode.
    #> (Ensue (lambda (step)
    #..         (attach step :
    #..           Y '(1 2 3 4 5)

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3543,7 +3543,35 @@ Lissp Whirlwind Tour
    msg
 
 
-   ;; Also XYZ# XYZW# See API doc.
+   ;; Combines an anaphoric lambda with an injected Python code string.
+   ;; The imports would have been harder if the whole expression were
+   ;; injected Python. Get the best of both worlds.
+   #> (XYZ#.#"X*Y == Z" : X math..pi  Y 2  Z math..tau) ;Or inject the 2.
+   >>> (lambda X,Y,Z:X*Y == Z)(
+   ...   X=__import__('math').pi,
+   ...   Y=(2),
+   ...   Z=__import__('math').tau)
+   True
+
+
+   ;; Slicing takes up to four operands.
+   #> (XYZW#.#"X[Y:Z:W]" "QuaoblcldefHg" -2 1 -2)
+   >>> (lambda X,Y,Z,W:X[Y:Z:W])(
+   ...   ('QuaoblcldefHg'),
+   ...   (-2),
+   ...   (1),
+   ...   (-2))
+   'Hello'
+
+
+   ;; Slicing is important enough for a shorthand.
+   ;; This variant works best on simple cases. The slice indexes are all
+   ;; injected Python here.
+   #> ([#-2:1:-2] "QuaoblcldefHg")
+   >>> (lambda _QzNo32_G:(_QzNo32_G[-2:1:-2]))(
+   ...   ('QuaoblcldefHg'))
+   'Hello'
+
 
    #> b#"bytes"                           ;Bytes reader macro.
    >>> b'bytes'
@@ -3768,7 +3796,7 @@ Lissp Whirlwind Tour
    'a'
 
 
-   #> (get#(slice None None -1) "abc")    ;Slicing.
+   #> (get#(slice None None -1) "abc")    ;Slicing without injection.
    >>> __import__('operator').itemgetter(
    ...   slice(
    ...     None,

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -4079,3 +4079,60 @@ Lissp Whirlwind Tour
    ...    '        print(i+j, end=" ")\n'
    ...    "print('.')\n"))
    ax ay az bx by bz cx cy cz .
+
+
+   ;;; 20.3 Decorators
+
+   ;; Decorator syntax is for global definitions, like define and
+   ;; deftype, but would work on any global definition macro that has
+   ;; the (unqualified) defined name as its first argument.
+
+   ;; Unlike Python's def, define doesn't have to define a function.
+   #> @#!str.swapcase
+   #..@#!str.title
+   #..(define spam 'spam)
+   >>> # hissp.macros.._macro_.define
+   ... __import__('builtins').globals().update(
+   ...   spam=# hissp.macros.._macro_.progn
+   ...        (lambda :(
+   ...          # hissp.macros.._macro_.define
+   ...          __import__('builtins').globals().update(
+   ...            spam=# hissp.macros.._macro_.progn
+   ...                 (lambda :(
+   ...                   # define
+   ...                   __import__('builtins').globals().update(
+   ...                     spam='spam'),
+   ...                   str.title(
+   ...                     spam))[-1])()),
+   ...          str.swapcase(
+   ...            spam))[-1])())
+
+
+   #> spam
+   >>> spam
+   'sPAM'
+
+
+   ;; Locals are single-assignment in Hissp (unless you inject a :=,
+   ;; which is not recommended), so the decorator sugar for reassignment
+   ;; after a tranform wouldn't make sense. This doesn't stop you from
+   ;; e.g. using method decorators without the sugar in a deftype.
+   #> (deftype Spam ()
+   #..  spam (staticmethod
+   #..        (lambda : (print "spam spam spam"))))
+   >>> # deftype
+   ... # hissp.macros.._macro_.define
+   ... __import__('builtins').globals().update(
+   ...   Spam=__import__('builtins').type(
+   ...          'Spam',
+   ...          (lambda * _: _)(),
+   ...          __import__('builtins').dict(
+   ...            spam=staticmethod(
+   ...                   (lambda :
+   ...                     print(
+   ...                       ('spam spam spam')))))))
+
+
+   #> (.spam (Spam))
+   >>> Spam().spam()
+   spam spam spam

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2896,10 +2896,10 @@ Lissp Whirlwind Tour
 
    ;; You can nest them.
    #> (engarde Exception                                               ;The outer engarde
-   #..  print
-   #..  engarde ZeroDivisionError                                      ; calls the inner.
-   #..  (lambda e (print "It means what you want it to mean."))
-   #..  truediv "6" 0)                                                 ;Try variations.
+   #.. print
+   #.. engarde ZeroDivisionError                                       ; calls the inner.
+   #.. (lambda e (print "It means what you want it to mean."))
+   #.. truediv "6" 0)                                                  ;Try variations.
    >>> engarde(
    ...   Exception,
    ...   print,


### PR DESCRIPTION
It really is just docs this time.

My contrast tweak was apparently not displaying by default. You had to explicitly switch to light or dark theme, which many probably wouldn't know they could do. Code snippets with a lot of commentary (i.e. the Whirlwind Tour) should be easier to read now.

Also added the new macros that were missing from the Whirlwind Tour. It should again be fairly complete now.