### PR TITLE
Eliminate attrgetter- @# overload

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Requires [Bottle.](https://bottlepy.org/docs/dev/)
     (tag "body onload='brython()'" ; Browser Python: https://brython.info
      (script
        (define getE X#(.getElementById browser..document X))
-       (define getf@v X#(float (@#value (getE X))))
+       (define getf@v X#(float (X#X.value (getE X))))
        (define set@v XY#(setattr (getE Y) 'value X))
        (attach browser..window
          : Celsius &#(-> (getf@v 'Celsius) (X#.#"X*1.8+32") (set@v 'Fahrenheit))

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -605,7 +605,7 @@ Lissp Whirlwind Tour
           (lambda () (print "Unrecognized input."))))
 
    ;; Don't worry, Hissp metaprogramming will make this much easier,
-   ;; but our limited tools so far are enough to implement a ternary.
+   ;; but our limited tools so far are enough for a ternary operator.
 
    #> (.update (globals) : bool->caller (dict))
    >>> globals().update(
@@ -3543,7 +3543,7 @@ Lissp Whirlwind Tour
    msg
 
 
-   ;; Combines an anaphoric lambda with an injected Python code string.
+   ;; Ternary anaphoric lambda, applied to an injected code string.
    ;; The imports would have been harder if the whole expression were
    ;; injected Python. Get the best of both worlds.
    #> (XYZ#.#"X*Y == Z" : X math..pi  Y 2  Z math..tau) ;Or inject the 2.
@@ -3554,7 +3554,7 @@ Lissp Whirlwind Tour
    True
 
 
-   ;; Slicing takes up to four operands.
+   ;; Quaternary anaphoric lambda. Slicing takes up to four operands.
    #> (XYZW#.#"X[Y:Z:W]" "QuaoblcldefHg" -2 1 -2)
    >>> (lambda X,Y,Z,W:X[Y:Z:W])(
    ...   ('QuaoblcldefHg'),
@@ -3602,7 +3602,8 @@ Lissp Whirlwind Tour
    <BLANKLINE>
 
 
-   ;; The en- reader macro.
+   ;; The en# reader macro converts a function applicable to one tuple
+   ;; to a function of its elements.
    #> (en#list 1 2 3)
    >>> (lambda *_QzNo31_xs:
    ...   list(
@@ -3626,7 +3627,7 @@ Lissp Whirlwind Tour
    [1, 2, 3, 4, 5, 6]
 
 
-   #> (en#collections..deque 1 2 3)       ;Generalizes to any function of 1 iterable.
+   #> (en#collections..deque 1 2 3)
    >>> (lambda *_QzNo31_xs:
    ...   __import__('collections').deque(
    ...     _QzNo31_xs))(
@@ -3636,7 +3637,7 @@ Lissp Whirlwind Tour
    deque([1, 2, 3])
 
 
-   ;; Anaphoric lambda of any number of args.
+   ;; Applying en# to X# results in a variadic anaphoric lambda.
    #> (define enjoin en#X#(.join "" (map str X)))
    >>> # define
    ... __import__('builtins').globals().update(
@@ -3661,6 +3662,9 @@ Lissp Whirlwind Tour
    ...   ('.'))
    'Sum: 5. Product: 6.'
 
+
+   ;; There are no bundled reader macros for a quinary, senary, etc. but
+   ;; the en#X# variadic or a normal lambda form can be used.
 
    ;; Not technically a reader macro, but a bundled macro for defining them.
    ;; Alias makes a new reader macro to abbreviate a qualifier.
@@ -3756,9 +3760,8 @@ Lissp Whirlwind Tour
    ['a', 1, 'b', 2, 'c', 3]
 
 
-   #> (@#upper "shout")                   ;Get an attribute without calling it.
-   >>> __import__('operator').attrgetter(
-   ...   'upper')(
+   #> (X#X.upper "shout")                 ;Get an attribute without calling it.
+   >>> (lambda X:X.upper)(
    ...   ('shout'))
    <built-in method upper of str object at ...>
 
@@ -3767,11 +3770,10 @@ Lissp Whirlwind Tour
    'SHOUT'
 
 
-   #> (define class-name @#__class__.__name__) ;Attributes chain.
+   #> (define class-name X#X.__class__.__name__) ;Attributes chain.
    >>> # define
    ... __import__('builtins').globals().update(
-   ...   classQz_name=__import__('operator').attrgetter(
-   ...                  '__class__.__name__'))
+   ...   classQz_name=(lambda X:X.__class__.__name__))
 
    #> (class-name object)
    >>> classQz_name(
@@ -3784,7 +3786,7 @@ Lissp Whirlwind Tour
    'str'
 
 
-   #> (define first get#0)                ;Similarly, for items.
+   #> (define first get#0)                ;Gets an item by key.
    >>> # define
    ... __import__('builtins').globals().update(
    ...   first=__import__('operator').itemgetter(

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -334,30 +334,15 @@ _#<<#
 (defmacro get\# e
   "``get#`` 'itemgetter-' Makes an `operator.itemgetter` function from ``e``.
 
-  See also: `@#<QzAT_QzHASH_>`, `operator.getitem`, `[#<QzLSQB_QzHASH_>`,
+  See also: `operator.getitem`, `[#<QzLSQB_QzHASH_>`,
   `set!<setQzBANG_>`.
   "
   `(op#itemgetter ,e))
 
-(defmacro @\# (primary : extra None)
-  "Overloaded, depending on the presence of ``extra``:
+(defmacro @\# (definition decoration)
+  "``@#!`` 'decorator' applies ``decoration`` to global and reassigns.
 
-  ``@#`` 'attrgetter-' Makes an `operator.attrgetter` from ``primary``,
-  which should be a symbol.
-
-  .. code-block:: REPL
-
-     #> (@#__class__.__name__.__class__.__name__ 0)
-     >>> __import__('operator').attrgetter(
-     ...   '__class__.__name__.__class__.__name__')(
-     ...   (0))
-     'str'
-
-  See also: `get#<getQzHASH_>`, `getattr`, `set@<setQzAT_>`.
-
-  ``@#!`` 'decorator' applies ``extra`` to defined name & reassigns.
-
-  ``primary`` form must assign a global identified by its first arg.
+  ``definition`` form must assign a global identified by its first arg.
   (E.g. `define` and `deftype` are compatible.) Expands to a `define`,
   meaning decorators can stack.
 
@@ -380,10 +365,8 @@ _#<<#
      'FOO'
 
   "
-  (if-else extra
-    (let (name (get#1 primary))
-      `(define ,name (progn ,primary (,extra ,name))))
-    `(op#attrgetter ',primary)))
+  (let (name (get#1 definition))
+    `(define ,name (progn ,definition (,decoration ,name)))))
 
 (defmacro \[\# e
   "``[#`` 'subscript' Injection. Python's subscription operator.
@@ -500,7 +483,7 @@ _#<<#
   Non-tuple ``forms`` (typically function identifiers) will be wrapped
   in a tuple. Makes chained method calls easier to read.
 
-  See also: `->><Qz_QzGT_QzGT_>`, `@#<QzAT_QzHASH_>`, `get#<getQzHASH_>`.
+  See also: `->><Qz_QzGT_QzGT_>`, `X#<XQzHASH_>`, `get#<getQzHASH_>`.
   "
   (functools..reduce XY#.#"(Y[0],X,*Y[1:],)"
                      (map X#.#"X if type(X) is tuple else (X,)" forms)


### PR DESCRIPTION
Use `X#X.foo.etc` instead. It's only two more characters, the same overhead as `get#`.