### PR TITLE
Smarter reader macros

### DIFF
--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3733,9 +3733,9 @@ Lissp Whirlwind Tour
    ... b'b# macro at compile time'
    b'b# macro at compile time'
 
-   #> hissp.._macro_.b\##"Fully qualified b# macro at read time."
-   >>> b'Fully qualified b# macro at read time.'
-   b'Fully qualified b# macro at read time.'
+   #> hissp.._macro_.b#"Fully-qualified b# macro at read time."
+   >>> b'Fully-qualified b# macro at read time.'
+   b'Fully-qualified b# macro at read time.'
 
 
    ;; A couple of aliases are bundled:

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -3693,9 +3693,8 @@ Lissp Whirlwind Tour
    ...               thenQz_else,
    ...               __import__('operator').not_(
    ...                 test))())(
-   ...             __import__('operator').contains(
-   ...               'hissp.._macro_',
-   ...               '_macro_'),
+   ...             'hissp.._macro_'.endswith(
+   ...               '._macro_'),
    ...             (lambda :'QzHASH_'),
    ...             (lambda :('')))))(
    ...         _QzNo27_prime,

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -607,23 +607,27 @@ but it can impact legibility.
 For short strings in simple forms,
 don't worry too much, but consider using ``\n``.
 
-For deeply nested multiline strings,
-use a dedent string, which can be safely indented:
+For deeply nested multiline string literals,
+consider indenting the string contents in combination with `textwrap.dedent`.
+The run-time overhead is usually negligible,
+but in case it matters,
+this can be done at read time instead:
 
 .. code-block:: REPL
 
-   #> (print (.upper 'textwrap..dedent#.##"\
-   #..               These lines
-   #..               Don't interrupt
-   #..               the flow."))
+   #> (print (.upper '.#(textwrap..dedent #"\
+   #..                   These lines
+   #..                   Don't interrupt
+   #..                   the flow.")))
    >>> print(
    ...   "These lines\nDon't interrupt\nthe flow.".upper())
    THESE LINES
    DON'T INTERRUPT
    THE FLOW.
 
-This required an inject ``.#``.
-Don't forget the quote ``'``.
+Because the string was injected (``.#``),
+don't forget to quote it (``'``),
+or the compiler will inject the string contents as Python code.
 
 With the principal exception of docstrings,
 long multiline strings should be declared at the `top level`_ and referenced by name.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -318,7 +318,7 @@ _#<<#
      (if-else $#reader
        ((getattr ,module (.format "{}{}"
                                   $#reader
-                                  (if-else (operator..contains ',module ','_macro_)
+                                  (if-else (.endswith ',module ','._macro_)
                                      ','#
                                      "")))
         $#prime : :* $#args)

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -26,7 +26,8 @@ from pprint import pformat
 from threading import Lock
 from typing import Any, Iterable, Iterator, NewType, Optional, Tuple, Union
 
-from hissp.compiler import Compiler, MAYBE, readerless
+import hissp.compiler as C
+from hissp.compiler import Compiler, readerless
 from hissp.munger import force_qz_encode, munge
 
 ENTUPLE = ("lambda",(":",":*"," _")," _",)  # fmt: skip
@@ -337,12 +338,12 @@ class Lissp:
         """Qualify symbol based on current context."""
         if not is_qualifiable(symbol):
             return symbol
-        if invocation and "_macro_" in self.ns and hasattr(self.ns["_macro_"], symbol):
-            return f"{self.qualname}.._macro_.{symbol}"  # Known macro.
+        if invocation and C.MACROS in self.ns and hasattr(self.ns[C.MACROS], symbol):
+            return f"{self.qualname}..{C.MACROS}.{symbol}"  # Known macro.
         if symbol in dir(builtins) and symbol.split(".", 1)[0] not in self.ns:
             return f"builtins..{symbol}"  # Known builtin, not shadowed (yet).
         if invocation and "." not in symbol:  # Could still be a recursive macro.
-            return f"{self.qualname}{MAYBE}{symbol}"
+            return f"{self.qualname}{C.MAYBE}{symbol}"
         return f"{self.qualname}..{symbol}"
 
     def gensym(self, form: str):
@@ -370,12 +371,12 @@ class Lissp:
         tag = munge(self.escape(tag[:-1]))
         if ".." in tag:
             module, function = tag.split("..", 1)
-            if re.match(r"_macro_\.[^.]+$", function):
+            if re.match(rf"{C.MACROS}\.[^.]+$", function):
                 function += munge("#")
             m = reduce(getattr, function.split("."), import_module(module))
         else:
             try:
-                m = getattr(self.ns["_macro_"], tag + munge("#"))
+                m = getattr(self.ns[C.MACROS], tag + munge("#"))
             except (AttributeError, KeyError):
                 raise SyntaxError(f"Unknown reader macro {tag!r}.", self.position())
         with self.compiler.macro_context():

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -370,6 +370,8 @@ class Lissp:
         tag = munge(self.escape(tag[:-1]))
         if ".." in tag:
             module, function = tag.split("..", 1)
+            if re.match(r"_macro_\.[^.]+$", function):
+                function += munge("#")
             m = reduce(getattr, function.split("."), import_module(module))
         else:
             try:


### PR DESCRIPTION
Parts of #174.

Fully-qualified reader macros now don't require `\#` if looked up from `_macro_`, same as aliases. This also means you _can't_ look up a non-reader macro and use as a fully-qualified reader macro. Would you ever want to do that? You can probably still inject those, but there may be edge cases involving unpicklable objects, which you could probably apply within the injected form as a normal invocation. If you can't, the workaround would be to assign a new name elsewhere.

Doesn't do extras for inject. I'm still considering that, but the implementation isn't trivial.