### PR TITLE
Docs continued

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,8 @@ Hissp is a *metaprogramming* intermediate language composed of simple Python dat
 easily generated programmatically,
 ```python
 >>> hissp_code = (
-... ('lambda',('name',),
-...  ('print',('quote','Hello'),'name',),)
+... ('lambda',('name',)
+...  ,('print',('quote','Hello'),'name',),)
 ... )
 
 ```
@@ -112,25 +112,25 @@ Strings also have a few special cases:
 * and module handles, which end with `.` (and do imports).
 ```python
 >>> adv_hissp_code = (
-... ('lambda',  # Anonymous function special form.
+... ('lambda'  # Anonymous function special form.
 ...  # Parameters.
-...  (':',  # Control word: remaining parameters are paired with a target.
-...   'name',  # Target: Raw Python: Parameter identifier.
-...   # Default value for name.
-...   ('quote',  # Quote special form: string, not identifier. 
-...    'world'),),
+...  ,(':'  # Control word: remaining parameters are paired with a target.
+...    ,'name'  # Target: Raw Python: Parameter identifier.
+...    # Default value for name.
+...    ,('quote'  # Quote special form: string, not identifier. 
+...      ,'world'),)
 ...  # Body.
-...  ('print',  # Function call form, using the identifier for the builtin.
-...   ('quote','Hello,'),),
-...  ('print',
-...   ':',  # Control word: Remaining arguments are paired with a target.
-...   ':*',  # Target: Control word for unpacking.
-...   ('.upper','name',),  # Method calls start with a dot.
-...   'sep',  # Target: Keyword argument.
-...   ':',  # Control words compile to strings, not raw Python.
-...   'file',  # Target: Keyword argument.
-...   # Module handles like `sys.` end in a dot.
-...   'sys..stdout',),)  # print already defaults to stdout though.
+...  ,('print'  # Function call form, using the identifier for the builtin.
+...    ,('quote','Hello,'),)
+...  ,('print'
+...    ,':'  # Control word: Remaining arguments are paired with a target.
+...    ,':*'  # Target: Control word for unpacking.
+...    ,('.upper','name',)  # Method calls start with a dot.
+...    ,'sep'  # Target: Keyword argument.
+...    ,':'  # Control words compile to strings, not raw Python.
+...    ,'file'  # Target: Keyword argument.
+...    # Module handles like `sys.` end in a dot.
+...    ,'sys..stdout',),)  # print already defaults to stdout though.
 ... )
 ...
 >>> print(readerless(adv_hissp_code))
@@ -184,9 +184,9 @@ extending that ability to custom tuple forms.
 ...         return ('branch',condition,('thunk',consequent,),('thunk',alternate,),)
 ...
 >>> expansion = readerless(
-...     ('if_else','0==1',  # Macro form, not a run-time call.
-...       ('print',('quote','yes',),),  # Side effect not evaluated!
-...       ('print',('quote','no',),),),
+...     ('if_else','0==1'  # Macro form, not a run-time call.
+...      ,('print',('quote','yes',),)  # Side effect not evaluated!
+...      ,('print',('quote','no',),),),
 ...     globals())  # Pass in globals for _macro_.
 >>> print(expansion)
 # if_else

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -21,9 +21,6 @@ Lissp Whirlwind Tour
 
 .. Lissp::
 
-   ;;;; LISSP WHIRLWIND TOUR ;;;;
-   ;;;  === 
-
    "Lissp is a lightweight text language representing the Hissp
    intermediate language. The Lissp reader parses the Lissp language's
    symbolic expressions as Python objects. The Hissp compiler
@@ -41,11 +38,11 @@ Lissp Whirlwind Tour
    Python and evaluate it. Try variations that occur to you.
 
    Familiarity with another Lisp dialect is not assumed, but helpful. If
-   you get confused or stuck, the Hissp primer is easier.
+   you get confused or stuck, look for the Hissp community chat or try the
+   Hissp Primer.
    "
 
    ;;;; 1 Installation
-   ;;;  ---
 
    ;;; These docs are for the latest development version of Hissp.
    ;;; Install the latest Hissp version with
@@ -58,12 +55,11 @@ Lissp Whirlwind Tour
    ;;; Report issues or try the current release version instead.
 
    ;;;; 2 Simple Atoms
-   ;;;  ---
 
    ;;; To a first approximation, the Hissp intermediate language is made
    ;;; of Python tuples representing syntax trees. The nodes are tuples
-   ;;; and we call the leaves "atoms". Simple atoms in Lissp are written
-   ;;; the same way as Python.
+   ;;; and the leaves are called "atoms". Simple atoms in Lissp are
+   ;;; written the same way as Python.
 
    ;;;; 2.1 Singleton
 
@@ -152,7 +148,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 3 Simple Tuples
-   ;;;  ---
 
    ;; Tuples group any atoms with (). Data tuples start with '.
    #> '(None 2 3)
@@ -169,7 +164,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 4 Symbolic Atoms
-   ;;;  ---
 
    ;;;; 4.1 Identifiers
 
@@ -211,7 +205,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 5 Simple Forms and Calls
-   ;;;  ---
 
    ;;; "Forms" are any data structures that can be evaluated as a Hissp program.
    ;;; Simple atoms are forms. They simply evaluate to an equivalent object.
@@ -295,7 +288,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 6 String Atoms
-   ;;;  ---
 
    #> :control-word                       ;Colon prefix. Similar to Lisp ":keywords".
    >>> ':control-word'
@@ -397,7 +389,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 7 Advanced Calls
-   ;;;  ---
 
    #> (dict :)                            ;Left paren before function! Notice the :.
    >>> dict()
@@ -522,7 +513,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 8 Simple Lambdas
-   ;;;  ---
 
    ;;; Lambdas are one of Hissp's two "special forms".
    ;;; They look like calls, but are special-cased in the Hissp compiler
@@ -685,7 +675,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 9 Advanced Lambdas
-   ;;;  ---
 
    ;; Python parameter types are rather involved. Lambda does all of them.
    ;; Like calls, they are all pairs. :? means no default.
@@ -784,7 +773,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 10 Quote
-   ;;;  ---
 
    ;;; Quote is the only other special form. Looks like a call, but isn't.
 
@@ -907,7 +895,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 11 Simple Reader Macros
-   ;;;  ---
 
    ;;; Reader macros are metaprograms to abbreviate Hissp and don't
    ;;; represent it directly. They apply to the next parsed Hissp object
@@ -1089,7 +1076,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 12 Compiler Macros
-   ;;;  ---
 
    ;;; We can use functions to to create forms for evaluation.
    ;;; This is metaprogramming: code that writes code.
@@ -1615,7 +1601,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 13 Compiling and Running Files
-   ;;;  ---
 
    ;;; ``$ lissp`` can run a .lissp file as __main__.
    ;;; You cannot import .lissp directly. Compile it to .py first.
@@ -1675,7 +1660,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 14 The Bundled Macros
-   ;;;  ---
 
    ;;; To make the REPL more usable, it comes with some basic macros already
    ;;; defined. Their design has been deliberately restricted so that their
@@ -2881,8 +2865,7 @@ Lissp Whirlwind Tour
    5040
 
 
-   ;;;; 15 Exception handling
-   ;;;  ---
+   ;;;; 15 Exception Handling
 
    ;; Defined by the prelude (§14.7). Guards against targeted exceptions.
    #> (engarde `(,FloatingPointError ,ZeroDivisionError)               ;two targets
@@ -2999,7 +2982,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 16 Generators
-   ;;;  ---
 
    ;; Defined by the prelude (§14.7), Ensue gives you infinite lazy
    ;; iterables, easy as recursion. Compare to loop-from (§14.8).
@@ -3186,7 +3168,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 17 Context Managers
-   ;;;  ---
 
    #> (define wrap
    #..  (contextlib..contextmanager
@@ -3334,7 +3315,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 18 Advanced Reader Macros
-   ;;;  ---
 
    ;;;; 18.1 The Discard Macro
 
@@ -3491,7 +3471,6 @@ Lissp Whirlwind Tour
 
 
    ;;;; 19 The Bundled Reader Macros
-   ;;;  ---
 
    ;;; Like the other bundled macros, these are available in the REPL by
    ;;; default, but most other contexts, like .lissp files, require fully-

--- a/docs/primer.rst
+++ b/docs/primer.rst
@@ -71,8 +71,8 @@ A Hissp program is made of Python objects in tuples
 which represent the syntax tree structure.
 
 >>> hissp_program = (
-...     ('lambda',('name',),
-...       ('print',('quote','Hello',),'name',),)
+...     ('lambda',('name',)
+...      ,('print',('quote','Hello',),'name',),)
 ... )
 
 You can invoke the Hissp compiler directly from Python.
@@ -135,8 +135,8 @@ Code is writing code!
 Let's use it.
 
 >>> readerless(
-...     ('lambda',('name'),
-...       ('print',q('Hello'),'name',),)
+...     ('lambda',('name')
+...      ,('print',q('Hello'),'name',),)
 ... )
 "(lambda n,a,m,e:\n  print(\n    'Hello',\n    name))"
 >>> print(_)  # Remember, _ is the last result that wasn't None.
@@ -175,8 +175,8 @@ Let's try that again,
 with the comma this time.
 
 >>> readerless(
-...     ('lambda',('name',),
-...       ('print',q('Hello'),'name',),)
+...     ('lambda',('name',)
+...      ,('print',q('Hello'),'name',),)
 ... )
 "(lambda name:\n  print(\n    'Hello',\n    name))"
 >>> print(_)
@@ -386,8 +386,8 @@ Recall that the Hissp-level `str` type is used to represent Python identifiers i
 and must be quoted with the ``quote`` special form to represent text data instead.
 
 >>> readerless(
-...     ('print',  # str containing identifier
-...      ('quote','hi'),)  # string as data
+...     ('print'  # str containing identifier
+...      ,('quote','hi'),)  # string as data
 ... )
 "print(\n  'hi')"
 >>> eval(_)
@@ -399,8 +399,8 @@ So another way to represent text data in Hissp
 is a Hissp-level string that contains the Python code for a string literal.
 
 >>> readerless(
-...     ('print',  # str containing identifier
-...      '"hi"',)  # str containing a string literal
+...     ('print'  # str containing identifier
+...      ,'"hi"',)  # str containing a string literal
 ... )
 'print(\n  "hi")'
 >>> eval(_)
@@ -495,7 +495,7 @@ but symbols only exist as a *reader syntax* in Lissp,
 where they represent the subset of Hissp-level strings that can act as identifiers.
 
 Symbols in Lissp become strings in Hissp which become identifiers in Python,
-unless they're quoted, like ``('quote', 'Hello',)``,
+unless they're quoted, like ``('quote','Hello',)``,
 in which case they become string literals in Python.
 
 Experiment with this process in the REPL.
@@ -1526,10 +1526,10 @@ If we format that a little more nicely,
 then it's easier to read.
 
 >>> readerless(
-...     (('lambda',(':',':*',' _',),' _'),
-...      ':',':?',':a',
-...      ':*',"('bcd')",
-...      ':?',('operator..mul', 2, 3,),)
+...     (('lambda',(':',':*',' _',),' _')
+...      ,':',':?',':a'
+...      ,':*',"('bcd')"
+...      ,':?',('operator..mul', 2, 3,),)
 ... )
 "(lambda * _: _)(\n  ':a',\n  *('bcd'),\n  __import__('operator').mul(\n    (2),\n    (3)))"
 >>> print(_)

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -359,7 +359,7 @@ so you know when to break them.
 Sometimes differences of opinion come down to taste.
 Use your best judgement;
 it's not always black and white.
-But not all shades of gray are the same either.
+(But don't make the worse mistake of thinking there's only one shade of gray ;)
 
 Lisp is one of the oldest programming languages in common use.
 It has splintered into many dialects (Lissp among them),
@@ -662,8 +662,8 @@ Prefer "why"-comments that describe rationale or intent.
    quote has its own line. Use reStructuredText markup in docstrings.
    "
 
-   ;;;; Major Section Heading ;;;;
-   ;;;  ---
+   ;;;; ** Decorated Major Section Heading **
+   ;;;  ***
 
    ;;; Long Exposition about this section. Wrap at column 72.
 
@@ -672,7 +672,7 @@ Prefer "why"-comments that describe rationale or intent.
    ;;; and upper case, and an undecorated minor heading below. (The whole-
    ;;; file title is in the module docstring in this case, not a comment.)
 
-   ;;;; Minor Subsection Heading
+   ;;;; Undecorated Minor Subsection Heading
 
    ;; comment about macro
    (macro special1
@@ -728,6 +728,7 @@ but a traditional Lisp editor like Emacs ``lisp-mode`` would not.
 
 **Never** put a single-semicolon comment on its own line unless
 it's a continuation aligned to the margin!
+This one is about established tooling, not just taste.
 Traditional Lisp editors automatically indent these to column 40,
 and Lissp was designed to work with Emacs ``lisp-mode``.
 If you break this rule, others will have to fix all your comments,
@@ -772,6 +773,14 @@ begin with three semicolons and a space ``;;; Foo Bar``.
 Top-level comments are separated from code with a blank line.
 They are not indented.
 
+Standard usage for more than two semicolons varies with Lisp dialect,
+but they are consistently ony for the `top level`_ and have no indent.
+
+Some Lisp styles use triple and quadruple semicolons for headings and subheadings,
+but differ on which is which.
+To avoid confusion,
+do not use triple-semicolon comments as headings at all.
+
 Prefer module docstrings over top-level comments where applicable.
 Module docstrings are not for implementation details internal to their module.
 
@@ -792,89 +801,85 @@ they get their own line and start at the beginning of it.
 They have a blank line before (unless it's the first line) and after.
 They organize the code into sections.
 
-To make them more emphatic,
-headings can be decorated with
+Headings can be decorated with symbol characters to make them more emphatic.
 
-- four trailing semicolons ``;;;; X ;;;;``,
-- underlines ``;;;  ---``,
-- or written in ``;;;; UPPER CASE``.
+A Lissp file would typically be broken up into smaller modules before you need more than one or two heading levels.
+
+But for a project distributed as a single large file,
+you may want to develop a project style more levels than that,
+especially if you don't use classes to group functions.
 
 Avoid using
 
-- semicolons as underlines.
-- more than four semicolons in a row for heading levels.
-  (too difficult to distinguish at a glance)
+- semicolons as underlines or other header decoration.
+- more than four semicolons in a row.
+  (This is sometimes seen in Emacs Lisp to indicate heading levels,
+  but more than four semicolons in a row is too difficult to distinguish at a glance and must be counted.)
 - overlines for emphasis.
   (An overline is commonly seen in reStructuredText headings.
   but it can obscure the heading text when folding code in some editors.)
 - different underlining styles alone to distinguish levels.
   (Underlines are indistinguishable when folded.)
+- inconsistent decorations.
 
-A Lissp file would typically be broken up into smaller modules before you need more than one or two heading levels.
-But for a project distributed as a single large file,
-you may want more than that,
-especially if you don't use classes to group functions.
-
-The recommended six-level scheme follows.
-(Six is enough for HTML; which labels them H1, H2, H3, H4, H5, and H6.)
+Many levels are probably too rare to require a community (rather than project-level) standard,
+but here's an example scheme with six levels.
+(Six is enough for HTML, with H1-H6 tags.)
 
 .. code-block:: Lissp
 
-   ;;;; WHOLE FILE TITLE ;;;;
-   ;;;  ===
+   ;;;; ## WHOLE FILE TITLE ##
+   ;;;  ###
 
-   ;;;; I. Heading Two ;;;;
-   ;;;  ---
+   ;;;; ** I. Heading Two **
+   ;;;  ***
 
-   ;;;; I.A. HEADING THREE ;;;;
+   ;;;; ++ I.A. Heading Three ++
 
-   ;;;; I.A.1. Heading Four ;;;;
+   ;;;; -- I.A.1. Heading Four --
 
-   ;;;; I.A.1.a. HEADING FIVE
+   ;;;; .. I.A.1.a. Heading Five ..
 
    ;;;; I.A.1.a.i. Heading Six
 
-   ;;;; II. Folded H2 ;;;;...
+   ;;;; ** II. Folded H2 **...
+
+The mnemonic here is that symbol characters that have more points (and use more ink) are more emphatic:
+``#`` (8, H1); ``*`` (5 or 6, H2); ``+`` (4, H3); ``-`` (2, H4); ``.`` (1, H5); and H6 is undecorated.
 
 Note that the underline decoration itself is not a heading,
 and should not use four semicolons (but note the extra space).
 This rule makes headings easier to find and count with a text search,
 and makes it possible for tooling to display or manipulate them programmatically.
 Three characters are sufficient to suggest an underline;
-there is no need to match the length of the heading text.
+there is no need to match the length of the heading text
+(but that is also a possible style).
 
 The alphanumeric section outline numbering is not required,
 but if you number sections at all,
 it must be absolutely consistent with the heading level and position.
 Tooling can help you here, even if it's just grep-and-check.
+If you use outline numbering at all,
+the decorations are not required to distinguish levels and may be omitted instead.
 
-In a sufficiently small file,
-you may only need one level.
-You can use the simple undecorated H6 style.
-
-If you later find you need two,
-add the H2-style decorations to your major headings,
-and again use the simple undecorated H6 for the minor ones.
-
-In the unlikely case that you need more than this,
-start at the top and work your way down:
+Start at the top and work your way down:
 there should be only one H1 in a file (the title);
 keep the H2's for your major sections;
 and proceed in numerical order H3, H4, etc., without skipping any heading levels.
 This will minimize the number of heading style changes you need to make if you later find that you need another level.
-(This means that if you do not use all six levels, you will not have any H6's at all.)
+(This means that if you do not use all six levels, you will not have any undecorated H6's at all.)
 
 _#_#_#The Discard Macro
 +++++++++++++++++++++++
 
 The discard macro ``_#`` applied to a string literal is acceptable for long block comments.
-Several discard macros may be used in a row to comment out that many forms following them.
 
+Several discard macros may be used in a row to comment out that many forms following them.
 A discarded tuple may be used to contain scratch code during development,
 but as with line comments,
 commented-out code does not belong in version control.
 
-A discarded string is acceptable as commentary,
+A discarded string with code following it in line is acceptable as commentary,
 but use this style sparingly.
 Include an arrow or NB in the string to make it clear this is a comment and not just disabled code.
 
@@ -892,7 +897,7 @@ or more than one blank line in a row.
 In rare cases where those aren't enough levels or newlines and blank lines would spread things out too much,
 it is acceptable to additionally use discarded symbols like ``_#,``
 within a line to indicate greater separation than the extra spaces.
-(One may also use group comments ``;;`` between lines.
+(One may also use grouping comments ``;;`` between lines.
 These are greater separations than newlines, but smaller separations than blank lines.)
 
 "Docstrings"
@@ -900,7 +905,7 @@ These are greater separations than newlines, but smaller separations than blank 
 
 Prefer docstrings over comments where applicable.
 Docstrings are for describing the interface,
-not implementation of their object.
+not the implementation of their object.
 
 "Private" helper functions/classes/modules (conventionally named with a leading underscore)
 need not have docstrings at all,
@@ -908,20 +913,29 @@ but again prefer docstrings over comments when applicable,
 in which case they describe an interface internal to their object's container,
 but still do not their describe their object's implementation details.
 
-The first expression of a module is its docstring.
+The first expression of a module (if it compiles to a string literal) is its docstring.
 Prefer this form over assigning the ``__doc__`` global directly.
 
 The ``lambda`` special form does not create docstrings.
-However, you can attach a ``__doc__`` attribute to the lambda object,
+However, you can attach a ``.__doc__`` attribute to the lambda object after creating it,
 e.g. using the `attach` macro.
 
-The bundled `deftype` macro does not special-case docstrings.
+The bundled `deftype` macro does not have any special case for docstrings.
 Instead add a ``__doc__`` as its first key.
 
-Indent docstrings to match their opening `"`, even when attached afterwards.
+Indent docstrings to the same column as their opening ``"``
+(or to the ``#`` in an opening ``#"``),
+even when using something like the attach macro.
 This does put the leading whitespace inside the string itself,
 but Python tooling expects this in docstrings,
 and can strip it out when rendering help.
+
+If the docstring contains any newlines,
+the closing ``"`` gets its own line.
+
+It is acceptable to use reader macros that resolve to a string literal like `<<# <QzLT_QzLT_QzHASH_>`
+(which is useful for doctests),
+as long as the documentation text is also legible in the source code.
 
 Follow Python style on docstring contents.
 
@@ -936,7 +950,12 @@ or from their primary argument with whitespace.
    ' builtins..repr# .# (lambda :)        ;Bad.
    'builtins..repr#.#(lambda :)           ;Preferred.
 
-However, if a primary argument spans multiple lines,
+Separating the tag with a space is acceptable when the primary starts with a ``|`` character,
+because ``#|`` starts a block comment in other Lisp dialects.
+Any editor not specialized for Lissp may get confused.
+``#\|`` is an alternative.
+
+If a primary argument spans multiple lines,
 it's acceptable to separate with a newline,
 but be careful not to accidentally put a comment in between,
 unless you explicitly discard it.
@@ -984,7 +1003,7 @@ unless you explicitly discard it.
          (frobnicate a b c))
        arg)
 
-Extras may always be separated,
+Extras may always be separated from the tag,
 but only imply groups of extras with whitespace if they are semantically grouped.
 
 .. code-block:: Lissp
@@ -1064,10 +1083,10 @@ Python does not enforce this,
 but it's a very strong convention.
 
 For internal Lissp code,
-Python conventions are fine,
+Python naming conventions are still acceptable,
 but the munger opens up more characters.
-Something like ``*FOO-BAR*`` is a perfectly valid Lissp identifier,
-but it munges to ``QzSTAR_FOOQz_BARQzSTAR_``,
+Something like ``+FOO-BAR+`` is a perfectly valid Lissp identifier,
+but it munges to ``QzPLUS_FOOQz_BARQzPLUS_``,
 which is awkward to use from the Python side.
 
 Even in private areas,

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -225,20 +225,28 @@ you may have to turn it off.
 
    # Right.
    # fmt: off
-   ('define','fib',
-     ('lambda',('n',),
-       ('ifQz_else',('operator..le','n',2,),
-         'n',
-         ('operator..add',('fib',('operator..sub','n',1,),),
-                          ('fib',('operator..sub','n',2,),),),),),)
+   ('define','fib'
+    ,('lambda',('n',)
+      ,('ifQz_else',('operator..le','n',2,)
+        ,'n'
+        ,('operator..add',('fib',('operator..sub','n',1,),)
+                         ,('fib',('operator..sub','n',2,),),),),),)
    # fmt: on
 
-Note also that tuple commas are used as terminators,
-not separators,
+A few notes about tuple commas in readerless.
+The last element always ends with one (commas are used as terminators,
+not separators),
 even on the same line.
 This is to prevent the common error of forgetting the required trailing comma for a monuple.
 If your syntax highlighter can distinguish ``(x)`` from ``(x,)``, you may be OK without it.
-But this had better be the case for the whole team.
+But this had better be the case for the whole team and project.
+Be consistent.
+
+Also note that tuple commas do not end the line, but rather start the next one.
+This marks the head element as special, because it starts with a ``(`` instead of a ``,``,
+and naturally starts one column earlier.
+Linewise edits and indentation are also more consistent this way.
+Commas are not followed by a space except to imply groups (when an extra space would be used in Lissp).
 
 Unambiguous Indentation
 :::::::::::::::::::::::
@@ -526,8 +534,12 @@ Readerless style is similar:
 
 .. code-block:: Python
 
-   ('function','arg1','arg2',
-               ':','kw1','kwarg1', 'kw2','kwarg2',)
+   ('function','arg1','arg2'
+              ,':','kw1','kwarg1', 'kw2','kwarg2',)
+
+Note the space between 'kwarg1' and 'kw2' used to imply groups,
+which is absent after the other commas in the tuple.
+Also recall that commas start the line rather than ending it.
 
 Alignment styles can be bent a little in the interest of readability,
 especially for macros, but even for calls,

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -173,11 +173,11 @@ class Compiler:
         For example,
 
         >>> readerless(
-        ... ('lambda', ('a',':/','b',
-        ...             ':', 'e',1, 'f',2,
-        ...             ':*','args', 'h',4, 'i',':?', 'j',1,
-        ...             ':**','kwargs',),
-        ...   42,),
+        ... ('lambda', ('a',':/','b'
+        ...            ,':', 'e',1, 'f',2
+        ...            ,':*','args', 'h',4, 'i',':?', 'j',1
+        ...            ,':**','kwargs',)
+        ...  ,42,)
         ... )
         '(lambda a,/,b,e=(1),f=(2),*args,h=(4),i,j=(1),**kwargs:(42))'
 
@@ -187,9 +187,9 @@ class Compiler:
         effects.
 
         >>> print(readerless(
-        ... ('lambda', (':',':*','args',':**','kwargs',),
-        ...   ('print','args',),
-        ...   ('print','kwargs',),),
+        ... ('lambda', (':',':*','args',':**','kwargs',)
+        ...  ,('print','args',)
+        ...  ,('print','kwargs',),)
         ... ))
         (lambda *args,**kwargs:(
           print(
@@ -320,8 +320,8 @@ class Compiler:
         For example:
 
         >>> print(readerless(
-        ... ('print',1,2,3,
-        ...          ':','sep',('quote',":",), 'end',('quote',"\n\n",),)
+        ... ('print',1,2,3
+        ...         ,':','sep',('quote',":",), 'end',('quote',"\n\n",),)
         ... ))
         print(
           (1),

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -464,7 +464,7 @@ class Lissp:
 def is_hissp_string(form) -> bool:
     """Determines if form would directly represent a string in Hissp.
 
-    Allows "readerless mode"-style strings: ('quote', 'foo',)
+    Allows "readerless mode"-style strings: ('quote','foo',)
     and any string literal in a Hissp-level str: '"foo"'
     (including the "('foo')" form produced by the Lissp reader).
 


### PR DESCRIPTION
Header style still seems to be in flux. I'm not sure if I'm keeping this version either.

Changed comma style for Readerless, based on experience [here](https://github.com/gilch/hissp/discussions/182#discussioncomment-5644782).