### PR TITLE
Fix wrong name in subrepl issue

### DIFF
--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -291,7 +291,7 @@ class Lissp:
 
     def parse_macro(self, tag: str, form, extras):
         # fmt: off
-        """Apply a reader macro to a form.
+        R"""Apply a reader macro to a form.
 
         The built-in reader macros are handled here. They are
 

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -29,9 +29,10 @@ class LisspREPL(InteractiveConsole):
     Call interact() to start.
     """
 
+    # locals shadows the builtin, but that's the name in the superclass.
     def __init__(self, locals=None, filename="<console>"):
         super().__init__(locals, filename)
-        self.lissp = Lissp(ns=locals)
+        self.lissp = Lissp(locals.get("__name__", "__main__"), locals)
         self.locals = self.lissp.ns
 
     def runsource(self, source, filename="<input>", symbol="single"):


### PR DESCRIPTION
Template quotes need a name defined in the reader to work. The LisspREPL always assumed '__main__', but could have been embedded in some other module, so this assumption was wrong. Now assumes '__name__' (all modules have this, or they're broken), and falls back to '__main__' in case it was started with an empty namespace.