### PR TITLE
Fix LisspLexer

### DIFF
--- a/docs/lissp_lexer.py
+++ b/docs/lissp_lexer.py
@@ -17,9 +17,9 @@ class LisspLexer(RegexLexer):
     class CommentSubLexer(RegexLexer):
         tokens = {
             "root": [
-                (r";;;;.*", pt.Generic.Heading),
-                (r";;;.*", pt.Generic.Subheading),
-                (r";.*", pt.Comment),
+                (r";;;;.*\n( *;.*\n)*", pt.Generic.Heading),
+                (r"(?:;;;.*\n)+", pt.Generic.Subheading),
+                (r"(?: *;.*\n)+", pt.Comment),
             ]
         }
 
@@ -61,8 +61,8 @@ class LisspLexer(RegexLexer):
             (
                 TOKENS.pattern,
                 bygroups(
-                    using(CommentSubLexer),
                     pt.Text,  # whitespace
+                    using(CommentSubLexer),
                     pt.Error,  # badspace
                     pt.Punctuation,  # open
                     pt.Punctuation,  # close

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2696,31 +2696,6 @@ Lissp Whirlwind Tour
    (help _macro_.b\#)                  ;Unqualified reader macros live in _macro_ too.
 
 
-   ;; The en# reader macro converts a function applicable to one tuple
-   ;; to a function of its elements.
-   #> (en#list 1 2 3)
-   >>> (lambda *_QzNo31_xs:
-   ...   list(
-   ...     _QzNo31_xs))(
-   ...   (1),
-   ...   (2),
-   ...   (3))
-   [1, 2, 3]
-
-   #> (en#.extend _ 4 5 6)                ;Methods too.
-   >>> (lambda _QzNo31_self,*_QzNo31_xs:
-   ...   _QzNo31_self.extend(
-   ...     _QzNo31_xs))(
-   ...   _,
-   ...   (4),
-   ...   (5),
-   ...   (6))
-
-   #> _
-   >>> _
-   [1, 2, 3, 4, 5, 6]
-
-
    #> (en#collections..deque 1 2 3)
    >>> (lambda *_QzNo31_xs:
    ...   __import__('collections').deque(
@@ -2730,35 +2705,6 @@ Lissp Whirlwind Tour
    ...   (3))
    deque([1, 2, 3])
 
-
-   ;; Applying en# to X# results in a variadic anaphoric lambda.
-   #> (define enjoin en#X#(.join "" (map str X)))
-   >>> # define
-   ... __import__('builtins').globals().update(
-   ...   enjoin=(lambda *_QzNo55_xs:
-   ...            (lambda X:
-   ...              ('').join(
-   ...                map(
-   ...                  str,
-   ...                  X)))(
-   ...              _QzNo55_xs)))
-
-   #> (enjoin "Sum: "(add 2 3)". Product: "(mul 2 3)".")
-   >>> enjoin(
-   ...   ('Sum: '),
-   ...   add(
-   ...     (2),
-   ...     (3)),
-   ...   ('. Product: '),
-   ...   mul(
-   ...     (2),
-   ...     (3)),
-   ...   ('.'))
-   'Sum: 5. Product: 6.'
-
-
-   ;;; There are no bundled reader macros for a quinary, senary, etc. but
-   ;;; the en#X# variadic or a normal lambda form can be used.
 
    ;;; Not technically a reader macro, but a bundled macro for defining them.
    ;;; Alias makes a new reader macro to abbreviate a qualifier.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1669,6 +1669,33 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    >>> _
   ;;    [1, 2, 3, 4, 5, 6]
   ;;
+  ;;    #> (define enjoin en#X#(.join "" (map str X)))
+  ;;    >>> # define
+  ;;    ... __import__('builtins').globals().update(
+  ;;    ...   enjoin=(lambda *_QzNo55_xs:
+  ;;    ...            (lambda X:
+  ;;    ...              ('').join(
+  ;;    ...                map(
+  ;;    ...                  str,
+  ;;    ...                  X)))(
+  ;;    ...              _QzNo55_xs)))
+  ;;
+  ;;    #> (enjoin "Sum: "(op#add 2 3)". Product: "(op#mul 2 3)".")
+  ;;    >>> enjoin(
+  ;;    ...   ('Sum: '),
+  ;;    ...   __import__('operator').add(
+  ;;    ...     (2),
+  ;;    ...     (3)),
+  ;;    ...   ('. Product: '),
+  ;;    ...   __import__('operator').mul(
+  ;;    ...     (2),
+  ;;    ...     (3)),
+  ;;    ...   ('.'))
+  ;;    'Sum: 5. Product: 6.'
+  ;;
+  ;; There are no bundled reader macros for a quinary, senary, etc. but
+  ;; the en#X# variadic or a normal lambda form can be used instead.
+  ;;
   ;; See also: `X# <XQzHASH_>`.
   ;;
   (if-else (&& (op#is_ str (type f))

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -41,8 +41,8 @@ but you can override this by setting some other value here.
 
 TOKENS = re.compile(
     r"""(?x)
-     (?P<comment>(?:[ ]*;.*[\n])+)
-    |(?P<whitespace>[\n ]+)
+     (?P<whitespace>[\n ]+)
+    |(?P<comment>(?:[ ]*;.*[\n])+)
     |(?P<badspace>\s)  # Other whitespace not allowed.
     |(?P<open>\()
     |(?P<close>\))


### PR DESCRIPTION
#205 broke the doc's syntax highlighting in apparently any code blocks containing comments. This updates the LisspLexer for the new tokenization of Lissp.

A lot of the REPL examples also contain a trailing comment. In the real REPL, this would now produce a final continuation prompt. I'm debating whether to add that to the examples. It doesn't seem that important, but it's an inconsistency. This wouldn't be the only way the examples differ from the real REPL. They're separated by newlines for doctesting, but the real REPL currently doesn't do that. Also, the `>>>` and `...` are kind of simulated by the REPL. If you expand a macro the compiler inserts a Python comment, which would result in `>>>` twice in the actual Python interpreter.

This also finishes up the `en#` example move which was only partially done before. I don't think I'll keep the deque example.