### PR TITLE
Fix warnings

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -56,7 +56,7 @@ jobs:
     - name: Test install with pytest (including doctests)
       run: |
         python -c "import tests"  # Compiles hissp.basic on package import.
-        pytest -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
+        pytest -p no:cacheprovider -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
     - name: Codecov
       uses: codecov/codecov-action@v1.0.4
       with:

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -54,6 +54,8 @@ jobs:
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
     - name: Test install with pytest (including doctests)
+      env:
+        PYTHONWARNINGS: error
       run: |
         python -c "import tests"  # Compiles hissp.basic on package import.
         pytest -p no:cacheprovider -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -140,7 +140,7 @@ class Comment:
         self.token = token
 
     def contents(self):
-        return re.sub(r"\n$|(?m)^ *;+ ?", "", self.token)
+        return re.sub(r"(?m)\n$|^ *;+ ?", "", self.token)
 
     def __repr__(self):
         return f"Comment({self.token!r})"

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -88,29 +88,22 @@ def interact(locals=None):
 
 def force_main():
     """:meta private:"""
+    # Creates a new ``__main__`` to take the place of the current
+    # ``__main__`` module.
     __main__ = ModuleType("__main__")
     sys.modules["__main__"] = __main__
     sys.path.insert(0, "")
     return __main__
 
 
-def main(__main__=None):
+def main(__main__):
     """REPL command-line entry point.
-
-    If ``__main__`` is not provided, it creates a new one to take the
-    place of the current ``__main__`` module.
 
     `hissp.macros._macro_` is imported into the module namespace,
     making the bundled macros immediately available unqualified.
     """
-    if not __main__:
-        __main__ = force_main()
     repl = LisspREPL(locals=__main__.__dict__)
     import hissp.macros  # Here so repl can import before compilation.
 
     repl.locals["_macro_"] = SimpleNamespace(**vars(hissp.macros._macro_))
     repl.interact()
-
-
-if __name__ == "__main__":
-    main()

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -53,7 +53,7 @@ __name__='__main__' __package__=None
 
 
 def test_repl_read_exception():
-    out, err = cmd("python -m hissp.repl", ".#(operator..truediv 1 0)\n")
+    out, err = cmd("python -m hissp", ".#(operator..truediv 1 0)\n")
     assert ">>> # Compilation failed!\nTraceback (most recent call last):\n  F" in err
     assert "\nZeroDivisionError: division by zero" in err
     assert out.count("#> ") == 2


### PR DESCRIPTION
Fixes #212.

Also configures warnings to fail the workflow, which would have caught this issue, which I confirmed in https://github.com/gilch/hissp/actions/runs/5086943652/jobs/9141865517.

Turns out deprecation warnings don't even print by default. This may turn out to be too strict, but we'll cross that bridge when we come to it.