### PR TITLE
Improve error messages

### DIFF
--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -513,13 +513,19 @@ class Compiler:
         nl = "\n" if "\n" in r else ""
         return f"__import__('pickle').loads({nl}  # {r}\n    {dumps}\n)"
 
+    @staticmethod
+    def linenos(form):
+        lines = form.split("\n")
+        digits = len(str(len(lines)))
+        return "\n".join(f"{i:0{digits}} {line}" for i, line in enumerate(lines, 1))
+
     def eval(self, form: str, form_number: int) -> Tuple[str, ...]:
         """Execute compiled form, but only if evaluate mode is enabled."""
         try:
             if self.evaluate:
                 filename = (
                     f"<Compiled Hissp #{form_number} of {self.qualname}:\n"
-                    f"{_linenos(form)}\n"
+                    f"{self.linenos(form)}\n"
                     f">"
                 )
                 exec(compile(form, filename, "exec"), self.ns)
@@ -533,12 +539,6 @@ class Compiler:
                 )
             return form, "# " + exc.replace("\n", "\n# ")
         return (form,)
-
-
-def _linenos(form):
-    lines = form.split("\n")
-    digits = len(str(len(lines)))
-    return "\n".join(f"{i:0{digits}} {line}" for i, line in enumerate(lines, 1))
 
 
 def _join_args(*args):

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -54,9 +54,11 @@ def _trace(method):
         except Exception as e:
             self.error = e
             message = (
-                f"\nCompiler.{method.__name__}() {type(e).__name__}:\n {e}".replace(
-                    "\n", "\n# "
-                )
+                "\nCompiler.{}() {}:\n {}".format(
+                    method.__name__,
+                    type(e).__name__,
+                    format_exc() if method.__name__ == "macro" else e,
+                ).replace("\n", "\n# ")
                 + "\n"
             )
             return f"(>   >  > >>{pformat(expr)}<< <  <   <){message}"

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -54,7 +54,8 @@ class LisspREPL(InteractiveConsole):
             self.showtraceback()
             return False
         print(sys.ps1, source.replace("\n", f"\n{sys.ps2}"), sep="", file=sys.stderr)
-        return super().runsource(source, filename, symbol)
+        fn = f"<Compiled Hissp of {filename}:\n{self.lissp.compiler.linenos(source)}\n>"
+        return super().runsource(source, fn, symbol)
 
     def raw_input(self, prompt=""):
         """:meta private:"""


### PR DESCRIPTION
Some more progress on #32. Errors during macroexpansion were frustratingly opaque. Most of the macros I've written have been small, so I could get by, but this really hasn't been good enough for the more complex ones, like the "synexpand" from #220, so I finally decided to fix it.