### PR TITLE
Parsing quirks

### DIFF
--- a/src/hissp/munger.py
+++ b/src/hissp/munger.py
@@ -61,6 +61,14 @@ def munge(s: str) -> str:
     """
     if s.startswith(":"):
         return s  # control word
+    return force_munge(s)
+
+
+def force_munge(s: str) -> str:
+    """As `munge`, but skips the control word check.
+
+    Used for reader tags.
+    """
     # Always normalize identifiers:
     # >>> 𝐀 = 'MATHEMATICAL BOLD CAPITAL A'
     # >>> 'A' in globals()

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -30,7 +30,7 @@ from typing import Any, Iterable, Iterator, NewType, Optional, Tuple, Union, Lis
 
 import hissp.compiler as C
 from hissp.compiler import Compiler, readerless
-from hissp.munger import force_qz_encode, munge
+from hissp.munger import force_munge, force_qz_encode, munge
 
 GENSYM_BYTES = 5
 """
@@ -432,7 +432,7 @@ class Lissp:
 
     def _custom_macro(self, form, tag, extras):
         assert tag.endswith("#")
-        tag = munge(self.escape(tag[:-1]))
+        tag = force_munge(self.escape(tag[:-1]))
         m = (self._fully_qualified if ".." in tag else self._local)(tag)
         with self.compiler.macro_context():
             args, kwargs = parse_extras(extras)

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -453,8 +453,8 @@ class Lissp:
     @staticmethod
     def escape(atom):
         """Process the backslashes in a token."""
-        atom = atom.replace(r"\.", force_qz_encode("."))
-        return re.sub(r"\\(.)", lambda m: m[1], atom)
+        full_stop = force_qz_encode(".")
+        return re.sub(r"\\(.)", lambda m: full_stop if m[1] == "." else m[1], atom)
 
     @staticmethod
     def _string(v):

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -64,8 +64,9 @@ TOKENS = re.compile(
     |(?P<macro>
        ,@
       |['`,!]
-       # Any atom that ends in (an unescaped) ``#``
-      |(?:[^\\ \n"();#]|\\.)+[#]
+      |[.][#]
+      # Any atom that ends in ``#``, but not ``.#`` or ``\#``.
+      |(?:[^\\ \n"();#]|\\.)*(?:[^.\\ \n"();#]|\\.)[#]
      )
     |(?P<string>
       [#]?  # raw?
@@ -433,6 +434,7 @@ class Lissp:
     def _custom_macro(self, form, tag, extras):
         assert tag.endswith("#")
         tag = force_munge(self.escape(tag[:-1]))
+        tag = re.sub(r"(^\.)", lambda m: force_qz_encode(m[1]), tag)
         m = (self._fully_qualified if ".." in tag else self._local)(tag)
         with self.compiler.macro_context():
             args, kwargs = parse_extras(extras)

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -453,8 +453,9 @@ class Lissp:
     @staticmethod
     def escape(atom):
         """Process the backslashes in a token."""
-        full_stop = force_qz_encode(".")
-        return re.sub(r"\\(.)", lambda m: full_stop if m[1] == "." else m[1], atom)
+        return re.sub(
+            r"\\(.)", lambda m: force_qz_encode(m[1]) if m[1] in ".:" else m[1], atom
+        )
 
     @staticmethod
     def _string(v):

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -277,7 +277,7 @@ EXPECTED = {
          "QzLSQB_QzRSQB_QzBSOL_QzSEMI_QzAPOS_QzCOMMA_QzFULLxSTOP_QzSOL_",)
     ],
 
-    R"""\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \ """: [
+    R"""\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \\. \. \ """: [
         "QzDIGITxONE_",
         "QzDIGITxONE_2",
         "QzLSQB_QzRSQB_",
@@ -291,6 +291,8 @@ EXPECTED = {
         "QzAPOS_",
         "QzQUOT_",
         "QzBSOL_",
+        'QzBSOL_.',
+        'QzFULLxSTOP_',
         "QzSPACE_",
     ],
 

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -277,13 +277,14 @@ EXPECTED = {
          "QzLSQB_QzRSQB_QzBSOL_QzSEMI_QzAPOS_QzCOMMA_QzFULLxSTOP_QzSOL_",)
     ],
 
-    R"""\1 \12 \[] \(\) \{} \[] \; \# \` \, \' \" \\ \\. \. \ """: [
+    R"""\1 \12 \[] \(\) \{} \[] \: \; \# \` \, \' \" \\ \\. \. \ """: [
         "QzDIGITxONE_",
         "QzDIGITxONE_2",
         "QzLSQB_QzRSQB_",
         "QzLPAR_QzRPAR_",
         "QzLCUB_QzRCUB_",
         "QzLSQB_QzRSQB_",
+        "QzCOLON_",
         "QzSEMI_",
         "QzHASH_",
         "QzGRAVE_",


### PR DESCRIPTION
Resolves #149

No fix for `.`, `..`, or `....`. The EDN Hissps currently need the single `.` reserved, and traditional Lisp editors might consider that part of a dotted list, so it probably shouldn't be allowed as a symbol in Lissp without an escape. `....__class__` is valid (`<class 'ellipsis'>`), so allowing `....` would be weird. `..` is similarly ambiguous. Is it a method `.QzFULLxSTOP_`? A module handle `QzFULLxSTOP_.`? Escapes (`\`) should be required to disambiguate.

No change to handling of `##` (still a symbol, not a tag). I don't think I want to allow unescaped `#` in tags. Also, tags could apply to hash strings.

The other cases identified have been dealt with. This unfortunately complicates the code more than I would like, but seems worth it to deal with these edge cases.