### PR TITLE
Cache compiled modules

### DIFF
--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -1643,7 +1643,7 @@ Lissp Whirlwind Tour
    ...   ('(print "Hello from spam!")\n(.update (globals) : x 42)'))
    53
 
-   #> (hissp.reader..transpile __package__ 'spam 'eggs) ; Side effects on compilation
+   #> (hissp.reader..transpile __package__ 'spam 'eggs) ;Side effects on compilation.
    >>> __import__('hissp.reader',fromlist='?').transpile(
    ...   __package__,
    ...   'spam',
@@ -1652,19 +1652,19 @@ Lissp Whirlwind Tour
    Hello World!
 
 
-   #> spam..x                             ; and import!
-   >>> __import__('spam').x
-   Hello from spam!
-   42
-
-   #> spam..x                             ;Python caches imports.
+   #> spam..x                             ;Compiled modules are cached.
    >>> __import__('spam').x
    42
 
    #> eggs.
    >>> __import__('eggs')
-   Hello World!
    <module 'eggs' from ...>
+
+   #> (importlib..reload spam.)           ;Side effects again on .py reload.
+   >>> __import__('importlib').reload(
+   ...   __import__('spam'))
+   Hello from spam!
+   <module 'spam' from ...>
 
 
    #> (any (map (lambda f (os..remove f)) ;Cleanup.

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -14,11 +14,11 @@ import sys
 from contextlib import contextmanager, suppress
 from contextvars import ContextVar
 from functools import wraps
-from itertools import chain, takewhile, starmap
+from itertools import chain, starmap, takewhile
 from pprint import pformat
 from traceback import format_exc
 from types import ModuleType
-from typing import Iterable, List, NewType, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, NewType, Tuple, TypeVar, Union
 from warnings import warn
 
 PAIR_WORDS = {":*": "*", ":**": "**", ":?": ""}
@@ -95,16 +95,17 @@ class Compiler:
         self.abort = None
 
     @staticmethod
-    def new_ns(name, doc=None, package=None):
-        """Creates and initializes a dict namespace like a module,
-        with the given `__name__`, ``__doc__``, and `__package__`;
-        ``__builtins__``; an empty ``__annotations__``; and whatever
-        else Python currently adds to new module objects.
+    def new_ns(name, doc=None, package=None) -> Dict[str, Any]:
+        """Imports the named module, creating it if necessary.
+
+        Returns the module's ``__dict__``.
         """
         mod = ModuleType(name, doc)
         mod.__annotations__ = {}
         mod.__package__ = package
         mod.__builtins__ = builtins
+        if name != "__main__":
+            mod = sys.modules.setdefault(name, mod)
         return vars(mod)
 
     def compile(self, forms: Iterable) -> str:


### PR DESCRIPTION
This is required for defonce.

`transpile` will also set `__file__`.

Python modules are kind of complicated, but this at least gets `defonce` working, I think. I'm also not caching `__main__`, which is kind of the default. Making some other default would require deeper changes. I'm assuming that if you're `importlib..reload`ing what's going to be `__main__`, it's not going to be called that (or the reload would bypass the `if __name__ == "__main__"` guard and restart your app.