### PR TITLE
Rename `ands`, `ors`

### DIFF
--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ which includes Clojure-like persistent data structures.
 ```EDN
 0 ; from garden_of_edn import _this_file_as_main_; """#"
 (hissp/_macro_.prelude)
-(attach _macro_ . ors #hissp/$"_macro_.||", ands #hissp/$"_macro_.&&")
+(attach _macro_ . ands #hissp/$"_macro_.&&")
 (defmacro #hissp/$"m#" t (tuple (.extend [(quote pyrsistent/m) (quote .)] t)))
 (defmacro #hissp/$"j#" j (complex 0 j))
 

--- a/README.md
+++ b/README.md
@@ -405,7 +405,7 @@ which includes Clojure-like persistent data structures.
 ```EDN
 0 ; from garden_of_edn import _this_file_as_main_; """#"
 (hissp/_macro_.prelude)
-(attach _macro_ . ands #hissp/$"_macro_.&&")
+
 (defmacro #hissp/$"m#" t (tuple (.extend [(quote pyrsistent/m) (quote .)] t)))
 (defmacro #hissp/$"j#" j (complex 0 j))
 

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -1590,11 +1590,11 @@ Can we just iterate through the expression and check?
    #> (define max-X
    #..  (lambda (expr)
    #..    (max (map (lambda (x)
-   #..                (|| (when (is_ str (type x))
-   #..                      (let (match (re..fullmatch "X([1-9][0-9]*)" x))
-   #..                        (when match
-   #..                          (int (.group match 1)))))
-   #..                    0))
+   #..                (ors (when (is_ str (type x))
+   #..                       (let (match (re..fullmatch "X([1-9][0-9]*)" x))
+   #..                         (when match
+   #..                           (int (.group match 1)))))
+   #..                     0))
    #..              expr))))
    >>> # define
    ... __import__('builtins').globals().update(
@@ -1602,7 +1602,7 @@ Can we just iterate through the expression and check?
    ...             max(
    ...               map(
    ...                 (lambda x:
-   ...                   # QzVERT_QzVERT_
+   ...                   # ors
    ...                   (lambda x0,x1:x0 or x1())(
    ...                     # when
    ...                     (lambda b,c:c()if b else())(
@@ -1717,11 +1717,11 @@ Now we can fix ``max-X``.
    #> (define max-X
    #..  (lambda (expr)
    #..    (max (map (lambda (x)
-   #..                (|| (when (is_ str (type x))
-   #..                      (let (match (re..fullmatch "X([1-9][0-9]*)" x))
-   #..                        (when match
-   #..                          (int (.group match 1)))))
-   #..                    0))
+   #..                (ors (when (is_ str (type x))
+   #..                       (let (match (re..fullmatch "X([1-9][0-9]*)" x))
+   #..                         (when match
+   #..                           (int (.group match 1)))))
+   #..                     0))
    #..              (flatten expr)))))
    >>> # define
    ... __import__('builtins').globals().update(
@@ -1729,7 +1729,7 @@ Now we can fix ``max-X``.
    ...             max(
    ...               map(
    ...                 (lambda x:
-   ...                   # QzVERT_QzVERT_
+   ...                   # ors
    ...                   (lambda x0,x1:x0 or x1())(
    ...                     # when
    ...                     (lambda b,c:c()if b else())(
@@ -1790,11 +1790,11 @@ Let's review. The code you need to make the version we have so far is
    (define max-X
      (lambda (expr)
        (max (map (lambda (x)
-                   (|| (when (is_ str (type x))
-                         (let (match (re..fullmatch "X([1-9][0-9]*)" x))
-                           (when match
-                             (int (.group match 1)))))
-                       0))
+                   (ors (when (is_ str (type x))
+                          (let (match (re..fullmatch "X([1-9][0-9]*)" x))
+                            (when match
+                              (int (.group match 1)))))
+                        0))
                  (flatten expr)))))
 
    (define flatten
@@ -2082,9 +2082,9 @@ Here you go:
    #> (defmacro L (: :* expr)
    #..  `(lambda (,@(map (lambda (i)
    #..                     (.format "X{}" i))
-   #..                   (range 1 (add 1 (|| (max-X expr)
-   #..                                       (contains (flatten expr)
-   #..                                                 'X)))))
+   #..                   (range 1 (add 1 (ors (max-X expr)
+   #..                                        (contains (flatten expr)
+   #..                                                  'X)))))
    #..            :
    #..            ,@(when (contains (flatten expr)
    #..                              'Xi)
@@ -2108,7 +2108,7 @@ Here you go:
    ...            (1),
    ...            add(
    ...              (1),
-   ...              # QzVERT_QzVERT_
+   ...              # ors
    ...              (lambda x0,x1:x0 or x1())(
    ...                maxQz_X(
    ...                  expr),

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -1031,7 +1031,7 @@ if it's not obvious from the identifier.
 
 .. code-block:: Lissp
 
-   "``&&`` 'and'. Like Python's ``and`` operator, but for any number of arguments."
+   "``@#`` 'decorator' applies ``decoration`` to a global and reassigns."
 
 This way, all three name versions (munged, demunged, and pronounced)
 will appear in generated docs.

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1565,7 +1565,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ... (42)
      42
 
-  See also: `||<QzVERT_QzVERT_>`, `and`.
+  See also: `ors`, `and`.
   "
   (cond (not exprs) True
         (op#eq (len exprs) 1) (get#0 exprs)
@@ -1575,15 +1575,16 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
           ,([#0] exprs)
           ,@(map X#`O#,X ([#1:] exprs)))))
 
-(defmacro || (: :* exprs)
-  "``||`` 'or'. Shortcutting logical OR.
+(defmacro ors (: :* exprs)
+  "Variadic shortcutting logical OR.
+
   Returns the first true value, otherwise the last value.
   There is an implicit initial value of ``()``.
 
   .. code-block:: REPL
 
-     #> (|| True (print 'oops)) ; Shortcutting.
-     >>> # QzVERT_QzVERT_
+     #> (ors True (print 'oops)) ; Shortcutting.
+     >>> # ors
      ... (lambda x0,x1:x0 or x1())(
      ...   True,
      ...   (lambda :
@@ -1591,15 +1592,15 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ...       'oops')))
      True
 
-     #> (|| 42 False)
-     >>> # QzVERT_QzVERT_
+     #> (ors 42 False)
+     >>> # ors
      ... (lambda x0,x1:x0 or x1())(
      ...   (42),
      ...   (lambda :False))
      42
 
-     #> (|| () False 0 1)  ; or seeks the truth
-     >>> # QzVERT_QzVERT_
+     #> (ors () False 0 1)  ; or seeks the truth
+     >>> # ors
      ... (lambda x0,x1,x2,x3:x0 or x1()or x2()or x3())(
      ...   (),
      ...   (lambda :False),
@@ -1607,13 +1608,13 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ...   (lambda :(1)))
      1
 
-     #> (|| False)
-     >>> # QzVERT_QzVERT_
+     #> (ors False)
+     >>> # ors
      ... False
      False
 
-     #> (||)
-     >>> # QzVERT_QzVERT_
+     #> (ors)
+     >>> # ors
      ... ()
      ()
 
@@ -2573,7 +2574,7 @@ except ModuleNotFoundError:pass"
 
 (defmacro nil\# x
   "``nil#`` evaluates as ``x or ()``. Adapter for 'nil punning'."
-  `(|| ,x ()))
+  `(ors ,x ()))
 
 (defmacro ^*\# e
   "``^*#`` 'synexpand' concatenative mini-language expressions
@@ -2750,7 +2751,7 @@ except ModuleNotFoundError:pass"
         is? XY#(op#is_ X (type Y))
         str? X#(my.is? str X)
         startswith? XY#(&& (my.str? X) (.startswith X Y))
-        literal? X#(|| (op#eq () X) (not (op#contains (# tuple str) (type X))))
+        literal? X#(ors (op#eq () X) (not (op#contains (# tuple str) (type X))))
         quotation? X#(&& (my.is? tuple X) (op#eq 'quote (get#0 X)))
         control-word? X#(my.startswith? X ":")
         module-handle? X#(&& (my.str? X) (.endswith X "."))
@@ -2763,14 +2764,14 @@ except ModuleNotFoundError:pass"
         obj (next (.reads my.reader (.replace cmd "`" "")))
         arity+1 (op#add 1 my.arity))
       (set@ my.result
-        (case cmd (@ (if-else (|| (my.literal? my.obj)
-                                  (.startswith suffix ",")
-                                  (hissp.reader..is_lissp_string my.obj)
-                                  (my.control-word? my.obj)
-                                  (my.module-handle? my.obj)
-                                  (my.quotation? my.obj))
+        (case cmd (@ (if-else (ors (my.literal? my.obj)
+                                   (.startswith suffix ",")
+                                   (hissp.reader..is_lissp_string my.obj)
+                                   (my.control-word? my.obj)
+                                   (my.module-handle? my.obj)
+                                   (my.quotation? my.obj))
                        (if-else my.arity `(op#getitem ,(next my.iexprs) ,my.obj) my.obj)
-                       (if-else (|| my.arity (not (my.method? my.obj)))
+                       (if-else (ors my.arity (not (my.method? my.obj)))
                          `(,my.obj ,@(i#islice my.iexprs my.arity+1))
                          `((op#attrgetter ',([#1:] my.obj))
                            ,(next my.iexprs)))))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1566,7 +1566,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ... (42)
      42
 
-  See also: `ors`, `and`.
+  See also: `ors`, `and`, `all`, `when`.
   "
   (cond (not exprs) True
         (op#eq (len exprs) 1) (get#0 exprs)
@@ -1619,7 +1619,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ... ()
      ()
 
-  See also: `ands`, `bool`, `or`.
+  See also: `ands`, `bool`, `or`, `any`.
   "
   (cond (op#eq (len exprs) 1) (get#0 exprs)
         exprs

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1524,23 +1524,24 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
        (get#0 $#stack))))
 
 ;; I would have named this 'and, but that's a reserved word.
-(defmacro && (: :* exprs)
-  "``&&`` 'and'. Shortcutting logical AND.
+(defmacro ands (: :* exprs)
+  "Variadic shortcutting logical AND.
+
   Returns the first false value, otherwise the last value.
   There is an implicit initial value of ``True``.
 
   .. code-block:: REPL
 
-     #> (&& True True False) ; and finds the False
-     >>> # QzET_QzET_
+     #> (ands True True False) ; and finds the False
+     >>> # ands
      ... (lambda x0,x1,x2:x0 and x1()and x2())(
      ...   True,
      ...   (lambda :True),
      ...   (lambda :False))
      False
 
-     #> (&& False (print 'oops)) ; Shortcutting.
-     >>> # QzET_QzET_
+     #> (ands False (print 'oops)) ; Shortcutting.
+     >>> # ands
      ... (lambda x0,x1:x0 and x1())(
      ...   False,
      ...   (lambda :
@@ -1548,20 +1549,20 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ...       'oops')))
      False
 
-     #> (&& True 42)
-     >>> # QzET_QzET_
+     #> (ands True 42)
+     >>> # ands
      ... (lambda x0,x1:x0 and x1())(
      ...   True,
      ...   (lambda :(42)))
      42
 
-     #> (&&)
-     >>> # QzET_QzET_
+     #> (ands)
+     >>> # ands
      ... True
      True
 
-     #> (&& 42)
-     >>> # QzET_QzET_
+     #> (ands 42)
+     >>> # ands
      ... (42)
      42
 
@@ -1618,7 +1619,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ... ()
      ()
 
-  See also: `&&<QzET_QzET_>`, `bool`, `or`.
+  See also: `ands`, `bool`, `or`.
   "
   (cond (op#eq (len exprs) 1) (get#0 exprs)
         exprs
@@ -1678,7 +1679,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ...   (lambda _Qz2IKKUCBWz_G=(lambda _Qz2IKKUCBWz_x:
      ...     # hissp.macros.._macro_.ifQz_else
      ...     (lambda b,c,a:c()if b else a())(
-     ...       # hissp.macros.._macro_.QzET_QzET_
+     ...       # hissp.macros.._macro_.ands
      ...       (lambda x0,x1:x0 and x1())(
      ...         __import__('builtins').isinstance(
      ...           _Qz2IKKUCBWz_x,
@@ -1707,8 +1708,8 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   See also: `throw`, `throw*<throwQzSTAR_>`.
   "
   `(throw* (let ($#G (lambda ($#x)
-                       (if-else (&& (isinstance $#x type)
-                                    (issubclass $#x BaseException))
+                       (if-else (ands (isinstance $#x type)
+                                      (issubclass $#x BaseException))
                          ($#x) $#x)))
              (attach ($#G ,exception) : ,'__cause__ ($#G ,cause)))))
 
@@ -1848,8 +1849,8 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; See also: `X# <XQzHASH_>`.
   ;;
-  (if-else (&& (op#is_ str (type f))
-               (.startswith f "."))
+  (if-else (ands (op#is_ str (type f))
+                 (.startswith f "."))
     `(lambda ($#self : :* $#xs)
        (,f $#self $#xs))
     `(lambda (: :* $#xs)
@@ -1879,7 +1880,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; See also: `#<QzHASH_>`, `%<QzPCENT_>`.
   ;;
-  (when (&& xs (op#eq :* (get#-1 xs)))
+  (when (ands xs (op#eq :* (get#-1 xs)))
      (throw (SyntaxError "trailing :*")))
   (let (ixs (iter xs))
     `((lambda (: :* ,'xs) .#"[*xs]")
@@ -1910,7 +1911,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
 
   See also: `@<QzAT_>`, `%<QzPCENT_>`.
   "
-  (when (&& xs (op#eq :* (get#-1 xs)))
+  (when (ands xs (op#eq :* (get#-1 xs)))
      (throw (SyntaxError "trailing :*")))
   (let (ixs (iter xs))
     `((lambda (: :* ,'xs) .#"{*xs}")
@@ -2148,7 +2149,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    ...       (lambda _Qz2IKKUCBWz_G=(lambda _Qz2IKKUCBWz_x:
   ;;    ...         # hissp.macros.._macro_.ifQz_else
   ;;    ...         (lambda b,c,a:c()if b else a())(
-  ;;    ...           # hissp.macros.._macro_.QzET_QzET_
+  ;;    ...           # hissp.macros.._macro_.ands
   ;;    ...           (lambda x0,x1:x0 and x1())(
   ;;    ...             __import__('builtins').isinstance(
   ;;    ...               _Qz2IKKUCBWz_x,
@@ -2729,10 +2730,10 @@ except ModuleNotFoundError:pass"
      3.1622776601683795
 
   "
-  (if-else (&& e (op#is_ tuple (type e)))
+  (if-else (ands e (op#is_ tuple (type e)))
     (let-from (sym : :* args) e
-      (if-else (&& (op#is_ str (type sym))
-                   (re..search ".[:^]" (hissp..demunge sym)))
+      (if-else (ands (op#is_ str (type sym))
+                     (re..search ".[:^]" (hissp..demunge sym)))
         (._rewrite _macro_
          (re..findall "([/&@<>*:]|(?:[^,^`/&@<>*:]|`[,^/&@<>*:])+)(,?\^*)"
                       (hissp..demunge sym))
@@ -2750,11 +2751,11 @@ except ModuleNotFoundError:pass"
         : reader (hissp..reader.Lissp : ns (.get hissp.compiler..NS))
         is? XY#(op#is_ X (type Y))
         str? X#(my.is? str X)
-        startswith? XY#(&& (my.str? X) (.startswith X Y))
+        startswith? XY#(ands (my.str? X) (.startswith X Y))
         literal? X#(ors (op#eq () X) (not (op#contains (# tuple str) (type X))))
-        quotation? X#(&& (my.is? tuple X) (op#eq 'quote (get#0 X)))
+        quotation? X#(ands (my.is? tuple X) (op#eq 'quote (get#0 X)))
         control-word? X#(my.startswith? X ":")
-        module-handle? X#(&& (my.str? X) (.endswith X "."))
+        module-handle? X#(ands (my.str? X) (.endswith X "."))
         method? X#(my.startswith? X ".")
         exprs (list exprs)
         arity (.count suffix "^")

--- a/tests/test_macros.lissp
+++ b/tests/test_macros.lissp
@@ -116,23 +116,23 @@
         (operator..not_ (operator..mod i 7)))
       (self.assertEqual xs (enlist 1 2 3 4 5 6 7))))
 
-  test_&&
+  test_ands
   (lambda (self)
     (*#let (xs (list))
       (*#doto xs
-        (.append (*#&&))
-        (.append (*#&& 0))
-        (.append (*#&& 1))
-        (.append (*#&& 0 (.append xs :oops)))
-        (.append (*#&& 1 (.append xs 2)))
-        (.append (*#&& True
-                       (.append xs 3)
-                       (.append xs :oops)))
-        (.append (*#&& True
-                       (*#progn (.append xs 4)
-                                :oops)
-                       (.append xs 5)))
-        (.append (*#&& 1 2 (*#progn (.append xs 6) 7))))
+        (.append (*#ands))
+        (.append (*#ands 0))
+        (.append (*#ands 1))
+        (.append (*#ands 0 (.append xs :oops)))
+        (.append (*#ands 1 (.append xs 2)))
+        (.append (*#ands True
+                         (.append xs 3)
+                         (.append xs :oops)))
+        (.append (*#ands True
+                         (*#progn (.append xs 4)
+                                  :oops)
+                         (.append xs 5)))
+        (.append (*#ands 1 2 (*#progn (.append xs 6) 7))))
       (self.assertEqual (enlist True 0 1 0 2 None 3 None 4 5 None 6 7)
                         xs)))
 

--- a/tests/test_macros.lissp
+++ b/tests/test_macros.lissp
@@ -136,16 +136,16 @@
       (self.assertEqual (enlist True 0 1 0 2 None 3 None 4 5 None 6 7)
                         xs)))
 
-  test_||
+  test_ors
   (lambda (self)
     (*#let (xs (list))
       (*#doto xs
-        (.append (*# ||))
-        (.append (*# || 0))
-        (.append (*# || 1))
-        (.append (*# || 2 (.append xs :oops)))
-        (.append (*# || 0 (.append xs 3)))
-        (.append (*# || 0 (.append xs 5) 6)))
+        (.append (*#ors))
+        (.append (*#ors 0))
+        (.append (*#ors 1))
+        (.append (*#ors 2 (.append xs :oops)))
+        (.append (*#ors 0 (.append xs 3)))
+        (.append (*#ors 0 (.append xs 5) 6)))
       (self.assertEqual (enlist () 0 1 2 3 None 5 6)
                         xs)))
 


### PR DESCRIPTION
Resolves #240.

Certainly a breaking change, but an easy update as they're just renames.