### PR TITLE
Fragment syntax

### DIFF
--- a/docs/lissp_lexer.py
+++ b/docs/lissp_lexer.py
@@ -68,7 +68,9 @@ class LisspLexer(RegexLexer):
                     pt.Punctuation,  # close
                     pt.Operator,  # macro
                     pt.String,
+                    pt.String.Symbol,
                     pt.Error,  # continue
+                    pt.Error,  # unclosed
                     using(AtomSubLexer),
                     pt.Error,
                 ),

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -357,21 +357,17 @@ Lissp Whirlwind Tour
 
    ;;;; 6.3 String Literals
 
-   #> "raw string"
-   >>> ('raw string')
-   'raw string'
+   #> "a string"
+   >>> ('a string')
+   'a string'
 
    #> 'not-string'                        ;symbol
    >>> 'notQz_stringQzAPOS_'
    'notQz_stringQzAPOS_'
 
-   #> #"Say \"Cheese!\" \u263a"           ;Hash strings process Python escapes.
+   #> "Say \"Cheese!\" \u263a"            ;Python escape sequences.
    >>> ('Say "Cheese!" ☺')
    'Say "Cheese!" ☺'
-
-   #> "Say \"Cheese!\" \u263a"            ;Raw strings don't.
-   >>> ('Say \\"Cheese!\\" \\u263a')
-   'Say \\"Cheese!\\" \\u263a'
 
 
    #> "string
@@ -380,12 +376,6 @@ Lissp Whirlwind Tour
    #.."                                   ;Same as #"string\nwith\nnewlines\n".
    >>> ('string\nwith\nnewlines\n')
    'string\nwith\nnewlines\n'
-
-
-   #> "one\"
-   #..string\\"                           ;Tokenizer expects paired \'s, even raw.
-   >>> ('one\\"\nstring\\\\')
-   'one\\"\nstring\\\\'
 
 
    ;;;; 7 Advanced Calls
@@ -443,7 +433,7 @@ Lissp Whirlwind Tour
    #..       :* "xyz"                     ;:* is a repeatable positional target.
    #..       :** (dict : sep "-")         ;Target :** to unpack mapping.
    #..       flush True                   ;Kwargs still allowed after :**.
-   #..       :** (dict : end #"!?\n"))    ;Multiple :** allowed too.
+   #..       :** (dict : end "!?\n"))     ;Multiple :** allowed too.
    >>> print(
    ...   (1),
    ...   *('abc'),
@@ -1629,14 +1619,14 @@ Lissp Whirlwind Tour
 
    ;; Finds spam.lissp & eggs.lissp in the current package & compile to spam.py & eggs.py
    #> (.write_text (pathlib..Path "eggs.lissp")
-   #..             #"(print \"Hello World!\")")
+   #..             "(print \"Hello World!\")")
    >>> __import__('pathlib').Path(
    ...   ('eggs.lissp')).write_text(
    ...   ('(print "Hello World!")'))
    22
 
    #> (.write_text (pathlib..Path "spam.lissp")
-   #..             #"(print \"Hello from spam!\")
+   #..             "(print \"Hello from spam!\")
    #..(.update (globals) : x 42)")
    >>> __import__('pathlib').Path(
    ...   ('spam.lissp')).write_text(

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -656,7 +656,7 @@ this can be done at read time instead:
 
 .. code-block:: REPL
 
-   #> (print (.upper '.#(textwrap..dedent #"\
+   #> (print (.upper '.#(textwrap..dedent "\
    #..                   These lines
    #..                   Don't interrupt
    #..                   the flow.")))

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -324,7 +324,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      1::2::3
 
   See also:
-  `<\<# <QzLT_QzLT_QzHASH_>`, `attach`,
+  `<\\<# <QzLT_QzLT_QzHASH_>`, `attach`,
   `lambda <hissp.compiler.Compiler.function>`.
   "
   (let ($fn `$#fn)
@@ -865,16 +865,16 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    >>> __import__('hissp')._macro_.bQzHASH_
   ;;    <function _macro_.bQzHASH_ at ...>
   ;;
-  ;;    #> (H:#b\# "b# macro at compile time")
+  ;;    #> (H:#b\# |b# macro at compile time|)
   ;;    >>> # hissp.._macro_.bQzHASH_
   ;;    ... b'b# macro at compile time'
   ;;    b'b# macro at compile time'
   ;;
-  ;;    #> hissp.._macro_.b#"Fully-qualified b# macro at read time."
+  ;;    #> hissp.._macro_.b#|Fully-qualified b# macro at read time.|
   ;;    >>> b'Fully-qualified b# macro at read time.'
   ;;    b'Fully-qualified b# macro at read time.'
   ;;
-  ;;    #> H:##b"Read-time b# via alias."
+  ;;    #> H:##b|Read-time b# via alias.|
   ;;    >>> b'Read-time b# via alias.'
   ;;    b'Read-time b# via alias.'
   ;;
@@ -1259,7 +1259,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ([{'a'}, 'bc'], 'de')
 
   See also:
-  `-\<>><Qz_QzLT_QzGT_QzGT_>`, `X#<XQzHASH_>`, `get#<getQzHASH_>`.
+  `-\\<>><Qz_QzLT_QzGT_QzGT_>`, `X#<XQzHASH_>`, `get#<getQzHASH_>`.
   "
   (functools..reduce XY#.#"(Y[0],X,*Y[1:],)"
                      (map X#.#"X if type(X) is tuple else (X,)" forms)
@@ -1315,7 +1315,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
 
 (define _TAO
   (lambda s (-> (.join " " (re..findall "(?m)^# (.*)~$" (s hissp.)))
-                (.replace ":" #"\n"))))
+                (.replace ":" "\n"))))
 
 ;;;; Control Flow
 
@@ -1778,15 +1778,18 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> b#"bytes
+  ;;    #> b#|\xff'\n'||foo|
+  ;;    >>> b"\xff'\n'|foo"
+  ;;    b"\xff'\n'|foo"
+  ;;
+  ;;    #> b#.#"bytes
   ;;    #..with\nnewlines"
   ;;    >>> b'bytes\nwith\nnewlines'
   ;;    b'bytes\nwith\nnewlines'
   ;;
   (-> raw
-      ast..literal_eval
-      (.replace "'" "\'")
-      (.replace #"\n" "\n")
+      (.replace "'" '|\'|)
+      (.replace "\n" '|\n|)
       (-<>> (.format "b'{}'"))
       ast..literal_eval))
 
@@ -2485,7 +2488,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;      ...
   ;;    Exception
   ;;
-  `(exec ',(.format #"\
+  `(exec ',(.format "\
 from functools import partial,reduce
 from itertools import *;from operator import *
 def engarde(xs,h,f,/,*a,**kw):
@@ -2505,9 +2508,9 @@ _macro_=__import__('types').SimpleNamespace()
 try:exec('from {}._macro_ import *',vars(_macro_))
 except ModuleNotFoundError:pass"
                     __name__)
-    ,ns))(.##"\144efma\143ro" import(: :* args)
-          `(.##"p\162int"(.##"\143ode\143s..en\143ode"
-                          (_TAO .##"in\163pe\143\164..ge\164\163our\143e")','.##"ro\16413")))
+    ,ns))(.#"\144efma\143ro" import(: :* args)
+          `(.#"p\162int"(.#"\143ode\143s..en\143ode"
+                          (_TAO .#"in\163pe\143\164..ge\164\163our\143e")','.#"ro\16413")))
 
 ;;;; Advanced
 
@@ -2631,7 +2634,7 @@ except ModuleNotFoundError:pass"
   ``:`` NOP (no depth)
      Has no effect. A separator when no other magic applies.
 
-  They can be escaped with a backtick (:literal:`\``).
+  They can be escaped with a backtick (:literal:`\\``).
 
   Other terms are either callables or data, and read as Lissp.
 
@@ -2735,7 +2738,7 @@ except ModuleNotFoundError:pass"
       (if-else (ands (op#is_ str (type sym))
                      (re..search ".[:^]" (hissp..demunge sym)))
         (._rewrite _macro_
-         (re..findall "([/&@<>*:]|(?:[^,^`/&@<>*:]|`[,^/&@<>*:])+)(,?\^*)"
+         (re..findall <<#;([/&@<>*:]|(?:[^,^`/&@<>*:]|`[,^/&@<>*:])+)(,?\^*)
                       (hissp..demunge sym))
          : :* (map X#(.^*\# _macro_ X) args))
         `(,@(map X#(.^*\# _macro_ X) e))))

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -75,17 +75,16 @@ TOKENS = re.compile(
       |['`,]
       |[.][#]
       # Any atom that ends in ``#``, but not ``.#`` or ``\#``.
-      |(?:[^\\ \n"();#]|\\.)*(?:[^.\\ \n"();#]|\\.)[#]+
+      |(?:[^\\ \n"|();#]|\\.)*(?:[^.\\ \n"|();#]|\\.)[#]+
      )
     |(?P<string>
-      [#]?  # raw?
       "  # Open quote.
         (?:[^"\\]  # Any non-magic character.
            |\\(?:.|\n)  # Backslash only if paired, including with newline.
         )*  # Zero or more times.
       "  # Close quote.
      )
-    |(?P<injection>
+    |(?P<fragment>
       [|]  # open
         (?:[^|\n]  # No newlines or unpaired |.
            |[|][|]  # | only if paired.
@@ -94,10 +93,10 @@ TOKENS = re.compile(
      )
     |(?P<continue>
        [#]?"  # String not closed.
-      |[|]  # Injection not closed.
       |;.*  # Comment may need another line.
      )
-    |(?P<atom>(?:[^\\ \n"();]|\\.)+)  # Let Python deal with it.
+    |(?P<unclosed>[|])
+    |(?P<atom>(?:[^\\ \n"|();]|\\.)+)  # Let Python deal with it.
     |(?P<error>.)
     """
 )
@@ -267,8 +266,9 @@ class Lissp:
             elif k == "close":    return self._close()
             elif k == "macro":    yield from self._macro(v)
             elif k == "string":   yield self._string(v)
-            elif k == "injection":yield self._injection(v)
+            elif k == "fragment": yield self._fragment(v)
             elif k == "continue": raise self._continue()
+            elif k == "unclosed": raise SyntaxError("Unpaired |", self.position())
             elif k == "atom":     yield self.atom(v)
             else:                 raise self._error(k)
             # fmt: on
@@ -500,14 +500,11 @@ class Lissp:
 
     @staticmethod
     def _string(v):
-        if v[0] == "#":  # Let Python process escapes.
-            v = v.replace("\\\n", "").replace("\n", R"\n")
-            val = ast.literal_eval(v[1:])
-        else:  # raw
-            val = v[1:-1]  # Only remove quotes.
+        v = v.replace("\\\n", "").replace("\n", R"\n")
+        val = ast.literal_eval(v)
         return v if (v := pformat(val)).startswith("(") else f"({v})"
 
-    def _injection(self, v):
+    def _fragment(self, v):
         return v[1:-1].replace("||", "|")
 
     def _continue(self):

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -85,8 +85,16 @@ TOKENS = re.compile(
         )*  # Zero or more times.
       "  # Close quote.
      )
+    |(?P<injection>
+      [|]  # open
+        (?:[^|\\]  # Any non-magic character.
+           |\\(?:.|\n)  # Backslash only if paired, including with newline.
+        )*
+      [|]  # close
+     )
     |(?P<continue>
        [#]?"  # String not closed.
+      |[|]  # Injection not closed.
       |;.*  # Comment may need another line.
      )
     |(?P<atom>(?:[^\\ \n"();]|\\.)+)  # Let Python deal with it.
@@ -259,6 +267,7 @@ class Lissp:
             elif k == "close":    return self._close()
             elif k == "macro":    yield from self._macro(v)
             elif k == "string":   yield self._string(v)
+            elif k == "injection":yield self._injection(v)
             elif k == "continue": raise self._continue()
             elif k == "atom":     yield self.atom(v)
             else:                 raise self._error(k)
@@ -497,6 +506,9 @@ class Lissp:
         else:  # raw
             val = v[1:-1]  # Only remove quotes.
         return v if (v := pformat(val)).startswith("(") else f"({v})"
+
+    def _injection(self, v):
+        return re.sub(r"(?s)\\(.)", R'\1', v[1:-1])
 
     def _continue(self):
         return SoftSyntaxError("Incomplete string token.", self.position())

--- a/src/hissp/reader.py
+++ b/src/hissp/reader.py
@@ -87,8 +87,8 @@ TOKENS = re.compile(
      )
     |(?P<injection>
       [|]  # open
-        (?:[^|\\]  # Any non-magic character.
-           |\\(?:.|\n)  # Backslash only if paired, including with newline.
+        (?:[^|\n]  # No newlines or unpaired |.
+           |[|][|]  # | only if paired.
         )*
       [|]  # close
      )
@@ -508,7 +508,7 @@ class Lissp:
         return v if (v := pformat(val)).startswith("(") else f"({v})"
 
     def _injection(self, v):
-        return re.sub(r"(?s)\\(.)", R'\1', v[1:-1])
+        return v[1:-1].replace("||", "|")
 
     def _continue(self):
         return SoftSyntaxError("Incomplete string token.", self.position())

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -198,17 +198,18 @@ def test_repl_str_continue():
 
         x
         "
-        b#""
-        b#"foo bar"
-        b#"
+        b#.#""
+        b#.#"foo bar"
+        b#.#"
 
 
         "
-        b#"
+        b#.#"
 
         x"
-        (.decode b#"\\xff
-        foo" : errors 'ignore)
+        (.decode b#.#<<#;\\xff
+        ;; foo
+                 : errors 'ignore)
         """,
         out="""\
         """
@@ -220,7 +221,7 @@ def test_repl_str_continue():
         #> b'foo bar'
         #> #..#..#..b'\n\n\n'
         #> #..#..b'\n\nx'
-        #> #..'\nfoo'
+        #> #..#..'\nfoo'
         #> """,
         err="""\
         """

--- a/tests/test_macros.lissp
+++ b/tests/test_macros.lissp
@@ -228,7 +228,7 @@
 
   test_string_newline
   (lambda (self)
-    (self.assertEqual #"\
+    (self.assertEqual "\
 foo\
 bar\nbaz"
                   "foobar
@@ -238,7 +238,7 @@ baz")
 foo
 bar
 "
-                  #"\n\nfoo\nbar\n"))
+                  "\n\nfoo\nbar\n"))
 
   test_string_reader_macro
   (lambda (self)


### PR DESCRIPTION
Resolves #209.

Adds the `||`-delimited "fragment" tokens. `|` is no longer allowed unescaped in symbols, sorry, but Common Lisp has the same problem, and it is a design goal of Hissp to be mostly compatible with Lisp editors.

They currently don't allow newlines, which reduces (but does not eliminate) the problem with Parinfer. An internal `;` character is still a serious problem. https://github.com/oakmac/parinfer/issues/16 You should be able to inject a string instead as a workaround. Brackets might also be an issue but should be fine as long as they're paired. I think.

Eliminates the `#""`/`""` distinction. `""` are no longer raw. Use quoted fragments or comment strings instead.

I think this will make Lissp easier to understand overall, because it's closer to how the underlying Hissp works. But I still need to rewrite a lot of docs.