### PR TITLE
Custom `_macro_` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <!--
-Copyright 2019, 2020, 2021, 2022, 2023 Matthew Egan Odendahl
+Copyright 2019, 2020, 2021, 2022, 2023, 2024 Matthew Egan Odendahl
 SPDX-License-Identifier: Apache-2.0
 -->
 [![Gitter](https://badges.gitter.im/hissp-lang/community.svg)](https://gitter.im/hissp-lang/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge)

--- a/docs/primer.rst
+++ b/docs/primer.rst
@@ -1,4 +1,4 @@
-.. Copyright 2019, 2020, 2021, 2022, 2023 Matthew Egan Odendahl
+.. Copyright 2019, 2020, 2021, 2022, 2023, 2024 Matthew Egan Odendahl
    SPDX-License-Identifier: CC-BY-SA-4.0
 
 .. Hidden doctest adds bundled macros for REPL-consistent behavior.

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -1,4 +1,4 @@
-# Copyright 2019, 2020, 2021, 2022, 2023 Matthew Egan Odendahl
+# Copyright 2019, 2020, 2021, 2022, 2023, 2024 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
 
 """
@@ -300,16 +300,16 @@ class Compiler:
     def _qualified_macro(self, head, parts):
         try:
             if parts[0] == self.qualname:  # Internal?
-                return vars(self.ns[MACROS])[parts[2]]
+                return getattr(self.ns[MACROS], parts[2])
             return eval(self.str(head))
-        except (KeyError, AttributeError):
+        except (LookupError, AttributeError):
             if parts[1] != MAYBE:
                 raise
 
     def _unqualified_macro(self, head):
         try:
-            return vars(self.ns[MACROS])[head]
-        except KeyError:
+            return getattr(self.ns[MACROS], head)
+        except (LookupError, AttributeError):
             pass
 
     @contextmanager

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1,4 +1,4 @@
-;;; Copyright 2019, 2020, 2021, 2022, 2023 Matthew Egan Odendahl
+;;; Copyright 2019, 2020, 2021, 2022, 2023, 2024 Matthew Egan Odendahl
 ;;; SPDX-License-Identifier: Apache-2.0
 
 "Hissp's bundled macros.


### PR DESCRIPTION
This makes the compiler a little more consistent with the reader. Using the `_macro_` object's `__getattr__` as a hook for overriding invocations (for example, making the module a Lisp-2) was a use case I intended at least since version 0.2.0 as mentioned [in the old FAQ](https://hissp.readthedocs.io/en/v0.2.0/faq.html#is-hissp-a-lisp-1-or-a-lisp-2).

When I actually tried doing it, I noticed that the compiler would require a small tweak. That's this change.

There are some subtleties around how dots should be handled. I might need more experience with this version before I can say if further changes are warranted. For use cases I'm imagining, I think local invocations with single dots like `(self.foo)` should be overridable, but external invocations with double dots like `(builtins..print)` should not, although `(foo.._macro_.bar)` should probably be overridable via the `foo.` module's `_macro_` rather than the local one.

It's a bit tricky because `foo.bar.baz` is different from `(getattr foo 'bar.baz)`.