### PR TITLE
Update doc build for Python 3.10

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.8"
+    python: "3.10"
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -67,7 +67,7 @@ Lissp Whirlwind Tour
 
    ;; This is a FRAGMENT TOKEN.
    ;; You can put Python code inside and the compiler passes it through:
-   #> |print('Hello, World!')|            ;note surrounding ||
+   #> |print('Hello, World!')|                ;note surrounding ||
    >>> print('Hello, World!')
    Hello, World!
 
@@ -77,7 +77,7 @@ Lissp Whirlwind Tour
    ;;; Yeah, we're not done.
 
    ;; Escape a | by doubling it:
-   #> |bin(0b101_101 || 0b111_000)|       ;bitwise OR operator
+   #> |bin(0b101_101 || 0b111_000)|           ;bitwise OR operator
    >>> bin(0b101_101 | 0b111_000)
    '0b111101'
 
@@ -85,20 +85,20 @@ Lissp Whirlwind Tour
    ;;; There are a few special cases that don't simply pass through.
 
    ;; A MODULE HANDLE abbreviates an import expression:
-   #> |collections.abc.|                  ;note the .|
+   #> |collections.abc.|                      ;note the .|
    >>> __import__('collections.abc',fromlist='*')
    <module 'collections.abc' from '...'>
 
 
    ;; A FULLY-QUALIFIED IDENTIFIER can be thought of as getting
    ;; attributes from a module handle:
-   #> |math..tau.__class__|               ;note the ..
+   #> |math..tau.__class__|                   ;note the ..
    >>> __import__('math').tau.__class__
    <class 'float'>
 
 
    ;; This is a CONTROL WORD. It compiles to a string literal:
-   #> |:word|                             ;note the |:
+   #> |:word|                                 ;note the |:
    >>> ':word'
    ':word'
 
@@ -116,50 +116,50 @@ Lissp Whirlwind Tour
    ;;; The compiler assembles fragments according to simple rules.
    ;;; Tuples normally compile to function calls.
 
-   #> (|frozenset|)                       ;call a builtin
+   #> (|frozenset|)                           ;call a builtin
    >>> frozenset()
    frozenset()
 
-   #> (|print| |1| |2| |3|)               ;call with arguments
+   #> (|print| |1| |2| |3|)                   ;call with arguments
    >>> print(
    ...   1,
    ...   2,
    ...   3)
    1 2 3
 
-   #> (|print| (|set|) (|list|) (|dict|)) ;nested calls
+   #> (|print| (|set|) (|list|) (|dict|))     ;nested calls
    >>> print(
    ...   set(),
    ...   list(),
    ...   dict())
    set() [] {}
 
-   #> (|print| |*'abc'| |sep='-'|)        ;Python unpacking and keyword arg.
+   #> (|print| |*'abc'| |sep='-'|)            ;Python unpacking and keyword arg
    >>> print(
    ...   *'abc',
    ...   sep='-')
    a-b-c
 
-   #> (|'wow'.upper|)                     ;Method call.
+   #> (|'wow'.upper|)                         ;method call
    >>> 'wow'.upper()
    'WOW'
 
 
    ;; Method calls have a special case so you can separate them.
-   #> (|.upper| |'amazing'|)              ;note the |.
+   #> (|.upper| |'amazing'|)                  ;note the |.
    >>> 'amazing'.upper()
    'AMAZING'
 
 
    ;; What happens if you call an "empty name" in Python?
-   #> (|| |1| |*'abc'| |3|)               ;That's right, it makes a tuple!
+   #> (|| |1| |*'abc'| |3|)                   ;That's right, it makes a tuple!
    >>> (
    ...   1,
    ...   *'abc',
    ...   3)
    (1, 'a', 'b', 'c', 3)
 
-   #> (|dict| (|| (|| |1| |2|) (|| |3| |4|))) ;That's enough to make other collections.
+   #> (|dict| (|| (|| |1| |2|) (|| |3| |4|))) ;Make other collections with them.
    >>> dict(
    ...   (
    ...     (
@@ -170,12 +170,12 @@ Lissp Whirlwind Tour
    ...       4)))
    {1: 2, 3: 4}
 
-   #> (|| |1|)                            ;Be careful with single arguments.
+   #> (|| |1|)                                ;Be careful with single arguments.
    >>> (
    ...   1)
    1
 
-   #> (|| |1| ||)                         ;You forgot the comma before. Get it?
+   #> (|| |1| ||)                             ;Forgot the comma before. Get it?
    >>> (
    ...   1,
    ...   )
@@ -185,7 +185,7 @@ Lissp Whirlwind Tour
    ;;;; Lambda Special Forms
 
    ;; This looks like a function call, but it's a special case.
-   #> (|lambda| (|*xs|) |[*xs]|)          ; list-making lambda expression
+   #> (|lambda| (|*xs|) |[*xs]|)              ;list-making lambda expression
    >>> (lambda *xs: [*xs])
    <function <lambda> at 0x...>
 
@@ -209,7 +209,7 @@ Lissp Whirlwind Tour
    ... )
    <function <lambda> at 0x...>
 
-   #> (|.update| (|globals|) |factorial=_|) ; _ trick doesn't work in modules though
+   #> (|.update| (|globals|) |factorial=_|) ; _ doesn't work in modules though
    >>> globals().update(
    ...   factorial=_)
 
@@ -253,19 +253,19 @@ Lissp Whirlwind Tour
    ;;; Fragment tokens read as str atoms, but they're not the only kind
    ;;; of OBJECT TOKEN. In many cases, you can drop the ||.
 
-   #> |"I'm a string."|                   ;use | for a FRAGMENT TOKEN
+   #> |"I'm a string."|                       ;use | for a FRAGMENT TOKEN
    >>> "I'm a string."
    "I'm a string."
 
-   #> "I'm a string."                     ;use " for a UNICODE TOKEN
+   #> "I'm a string."                         ;use " for a UNICODE TOKEN
    >>> ("I'm a string.")
    "I'm a string."
 
-   #> (|quote| |"I'm a string."|)         ;makes sense
+   #> (|quote| |"I'm a string."|)             ;makes sense
    >>> '"I\'m a string."'
    '"I\'m a string."'
 
-   #> (|quote| "I'm a string")            ;What did you expect?
+   #> (|quote| "I'm a string")                ;What did you expect?
    >>> '("I\'m a string")'
    '("I\'m a string")'
 
@@ -274,11 +274,11 @@ Lissp Whirlwind Tour
    >>> ':control word'
    ':control word'
 
-   #> :control\ word                      ;use : for a CONTROL TOKEN (note \ )
+   #> :control\ word                          ;use : for a CONTROL TOKEN (note \ )
    >>> ':control word'
    ':control word'
 
-   #> (|quote| :control\ word)            ;same result
+   #> (|quote| :control\ word)                ;same result
    >>> ':control word'
    ':control word'
 
@@ -289,7 +289,7 @@ Lissp Whirlwind Tour
    >>> 0x_F00
    3840
 
-   #> 0xF00                               ;LITERAL TOKEN (note compilation changed!)
+   #> 0xF00                                   ;LITERAL TOKEN (note compilation)
    >>> (3840)
    3840
 
@@ -303,7 +303,7 @@ Lissp Whirlwind Tour
    ...  '4+2j',)
    ('None', 'False', '...', '42', '4e2', '4+2j')
 
-   #> (|quote| (None False ... 42 4e2 4+2j)) ;six literal tokens (note compilation!)
+   #> (|quote| (None False ... 42 4e2 4+2j))  ;six literal tokens (compilation!)
    >>> (None,
    ...  False,
    ...  ...,
@@ -317,11 +317,11 @@ Lissp Whirlwind Tour
    >>> object
    <class 'object'>
 
-   #> object                              ;SYMBOL TOKEN (compiles to identifier)
+   #> object                                  ;SYMBOL TOKEN (identifier)
    >>> object
    <class 'object'>
 
-   #> (quote object)                      ;both symbol tokens (still a str atom)
+   #> (quote object)                          ;both symbol tokens (str atoms)
    >>> 'object'
    'object'
 
@@ -330,15 +330,15 @@ Lissp Whirlwind Tour
    >>> __import__('math')
    <module 'math' ...>
 
-   #> math.                               ;symbol token (module handle)
+   #> math.                                   ;symbol token (module handle)
    >>> __import__('math')
    <module 'math' ...>
 
-   #> math..tau                           ;symbol token (fully-qualified identifier)
+   #> math..tau                               ;symbol token (fully-qualified)
    >>> __import__('math').tau
    6.283185307179586
 
-   #> (quote math..tau)                   ;it's still a str atom
+   #> (quote math..tau)                       ;it's still a str atom
    >>> 'math..tau'
    'math..tau'
 
@@ -346,19 +346,19 @@ Lissp Whirlwind Tour
    ;;;; Tagging Tokens
 
    ;; Invoke any fully-qualified callable on the next parsed object at READ TIME.
-   #> builtins..hex#3840                  ;fully-qualified name ending in # is a TAG
+   #> builtins..hex#3840                      ;fully-qualified name# is a TAG
    >>> 0xf00
    3840
 
-   #> builtins..ord#Q                     ;tags make literal notation extensible
+   #> builtins..ord#Q                         ;tags make notation extensible
    >>> (81)
    81
 
-   #> math..exp#1                         ;e^1. Or to whatever number. At read time.
+   #> math..exp#1                             ;e^1. Or to whatever. At read time.
    >>> (2.718281828459045)
    2.718281828459045
 
-   #> builtins..dict#((1 2) (3 4))        ;no quote or || (note compilation!)
+   #> builtins..dict#((1 2) (3 4))            ;no quote or || (note compilation!)
    >>> {1: 2, 3: 4}
    {1: 2, 3: 4}
 
@@ -367,12 +367,12 @@ Lissp Whirlwind Tour
    ;;; But when the atom lacks a Python literal notation, the compiler is
    ;;; in a pickle!
 
-   #> builtins..float#inf                 ;compiler had to fall back to a pickle expression
+   #> builtins..float#inf                     ;had to fall back to a pickle
    >>> # inf
    ... __import__('pickle').loads(b'Finf\n.')
    inf
 
-   #> fractions..Fraction## 2 3           ;add more #s for more arguments (note ##)
+   #> fractions..Fraction## 2 3               ;more #s for more args (note ##)
    >>> # Fraction(2, 3)
    ... __import__('pickle').loads(b'cfractions\nFraction\n(V2/3\ntR.')
    Fraction(2, 3)
@@ -380,11 +380,11 @@ Lissp Whirlwind Tour
 
    ;;; Fully-qualified tags are not the only type of tagging token.
 
-   #> builtins..complex# imag=2           ;keyword argument via KWARG TOKEN
+   #> builtins..complex# imag=2               ;keyword argument via KWARG TOKEN
    >>> (2j)
    2j
 
-   #> builtins..bytes##encoding=ascii|bytes| ; kwarg can be first (passed by name)
+   #> builtins..bytes##encoding=ascii|bytes|  ; kwarg can be first (pass-by-name)
    >>> b'bytes'
    b'bytes'
 
@@ -427,7 +427,7 @@ Lissp Whirlwind Tour
    'QzAPOS_xQzAPOS_'
 
 
-   #> builtins..complex# *=(4 2) ; unpacking via STARARG TOKEN (special tag Kwarg)
+   #> builtins..complex# *=(4 2) ; unpack via STARARG TOKEN (special tag Kwarg)
    >>> ((4+2j))
    (4+2j)
 
@@ -454,7 +454,7 @@ Lissp Whirlwind Tour
    ;;; read time and injects the resulting object directly into the Hissp
    ;;; tree, like a fully-qualified tag does.
 
-   #> '(1 2 (operator..add 1 2))          ;Quoting happens at compile time.
+   #> '(1 2 (operator..add 1 2))              ;Quoting happens at compile time.
    >>> ((1),
    ...  (2),
    ...  ('operator..add',
@@ -462,20 +462,20 @@ Lissp Whirlwind Tour
    ...   (2),),)
    (1, 2, ('operator..add', 1, 2))
 
-   #> '(1 2 .#(operator..add 1 2))        ;Inject happens at read time.
+   #> '(1 2 .#(operator..add 1 2))            ;Inject happens at read time.
    >>> ((1),
    ...  (2),
    ...  (3),)
    (1, 2, 3)
 
 
-   #> (fractions..Fraction 1 2)           ;Run time eval. Compiles to equivalent code.
+   #> (fractions..Fraction 1 2)               ;Run-time call. Equivalent compiled code.
    >>> __import__('fractions').Fraction(
    ...   (1),
    ...   (2))
    Fraction(1, 2)
 
-   #> .#(fractions..Fraction 1 2)         ;Read time eval. Reads as equivalent object.
+   #> .#(fractions..Fraction 1 2)             ;Read-time call. Equivalent read object.
    >>> # Fraction(1, 2)
    ... __import__('pickle').loads(b'cfractions\nFraction\n(V1/2\ntR.')
    Fraction(1, 2)
@@ -485,7 +485,7 @@ Lissp Whirlwind Tour
    ;; things like newlines and string escape codes.
    #> (lambda (a b c)
    #..  .#"(-b + (b**2 - 4*a*c)**0.5)
-   #..    /(2*a)") ; quadratic formula
+   #..    /(2*a)")                            ;quadratic formula
    >>> (lambda a, b, c:
    ...     (-b + (b**2 - 4*a*c)**0.5)
    ...         /(2*a)
@@ -495,15 +495,15 @@ Lissp Whirlwind Tour
 
    ;;;; Symbol Token Munging
 
-   #> '+                                  ;Read-time munging of invalid identifiers.
+   #> '+                                      ;read-time munging of invalid identifiers
    >>> 'QzPLUS_'
    'QzPLUS_'
 
-   #> 'Also-a-symbol!                     ;Alias for 'AlsoQzH_aQzH_symbolQzBANG_
+   #> 'Also-a-symbol!                         ;Alias for 'AlsoQzH_aQzH_symbolQzBANG_
    >>> 'AlsoQzH_aQzH_symbolQzBANG_'
    'AlsoQzH_aQzH_symbolQzBANG_'
 
-   #> '𝐀                                  ;Alias for 'A (Unicode normal form KC)
+   #> '𝐀                                      ;Alias for 'A (Unicode normal form KC)
    >>> 'A'
    'A'
 
@@ -511,22 +511,22 @@ Lissp Whirlwind Tour
    >>> 'QzH_QzLT_QzGT_QzGT_'
    'QzH_QzLT_QzGT_QzGT_'
 
-   #> :-<>>                               ;Doesn't represent identifier; doesn't munge.
+   #> :-<>>                                   ;doesn't represent identifier (no munge)
    >>> ':-<>>'
    ':-<>>'
 
-   #> :                                   ;Shortest control word.
+   #> :                                       ;shortest control word
    >>> ':'
    ':'
 
 
    ;;;; Escaping with \
 
-   #> 'SPAM\ \"\(\)\;EGGS                 ;These would terminate a symbol if not escaped.
+   #> 'SPAM\ \"\(\)\;EGGS                     ;would terminate symbol if not escaped
    >>> 'SPAMQzSPACE_QzQUOT_QzLPAR_QzRPAR_QzSEMI_EGGS'
    'SPAMQzSPACE_QzQUOT_QzLPAR_QzRPAR_QzSEMI_EGGS'
 
-   #> '\42                                ;Digits can't start identifiers.
+   #> '\42                                    ;digits can't start identifiers
    >>> 'QzDIGITxFOUR_2'
    'QzDIGITxFOUR_2'
 
@@ -538,11 +538,11 @@ Lissp Whirlwind Tour
    >>> 'QzBSOL_'
    'QzBSOL_'
 
-   #> '\a\b\c                             ;Escapes allowed, but not required here.
+   #> '\a\b\c                                 ;escapes allowed here (not required)
    >>> 'abc'
    'abc'
 
-   #> 1\2                                 ;Backslashes work in other tokens.
+   #> 1\2                                     ;backslashes work in other tokens
    >>> (12)
    12
 
@@ -575,7 +575,7 @@ Lissp Whirlwind Tour
    ...   sep="-")
    1-2-3
 
-   #> (print : :? 1  :? 2  :? 3  sep "-") ;:? is a positional target.
+   #> (print : :? 1  :? 2  :? 3  sep "-")     ;:? is a positional target.
    >>> print(
    ...   (1),
    ...   (2),
@@ -583,7 +583,7 @@ Lissp Whirlwind Tour
    ...   sep=('-'))
    1-2-3
 
-   #> (print 1 2 3 : sep "-")             ;Arguments before : implicitly pair with :?.
+   #> (print 1 2 3 : sep "-")                 ;Args before : implicitly pair with :?.
    >>> print(
    ...   (1),
    ...   (2),
@@ -606,13 +606,13 @@ Lissp Whirlwind Tour
 
 
    ;; You can do the same things without || using control words.
-   #> (print 1                            ;Implicitly a positional :? target.
-   #..       : :* "abc"                   ;Target :* to unpack iterable.
-   #..       :? 2                         ;:? is still allowed after :*.
-   #..       :* "xyz"                     ;:* is a repeatable positional target.
-   #..       :** |{"sep": "-"}|           ;Target :** to unpack mapping.
-   #..       flush True                   ;Kwargs still allowed after :**.
-   #..       :** |{"end": "!?\n"}|)       ;Multiple :** allowed too.
+   #> (print 1                                ;Implicitly a positional :? target.
+   #..       : :* "abc"                       ;Target :* to unpack iterable.
+   #..       :? 2                             ;:? is still allowed after :*.
+   #..       :* "xyz"                         ;:* is a repeatable positional target.
+   #..       :** |{"sep": "-"}|               ;Target :** to unpack mapping.
+   #..       flush True                       ;Kwargs still allowed after :**.
+   #..       :** |{"end": "!?\n"}|)           ;Multiple :** allowed too.
    >>> print(
    ...   (1),
    ...   *('abc'),
@@ -629,12 +629,12 @@ Lissp Whirlwind Tour
    ...   ('Hello, World!'))
    Hello, World!
 
-   #> (print "Hello, World!" :)           ;Same. Slid : over. Compare.
+   #> (print "Hello, World!" :)               ;Same. Slid : over. Compare.
    >>> print(
    ...   ('Hello, World!'))
    Hello, World!
 
-   #> (print "Hello, World!")             ;No : is the same as putting it last!
+   #> (print "Hello, World!")                 ;No : is the same as putting it last!
    >>> print(
    ...   ('Hello, World!'))
    Hello, World!
@@ -653,15 +653,15 @@ Lissp Whirlwind Tour
 
    ;; Lambda control words can do all of them.
    ;; Like calls, they are all pairs. :? means no default.
-   #> (lambda (: a :?  b :?  :/ :?        ;positional only
-   #..         c :?  d :?                 ;normal
-   #..         e 1  f 2                   ;default
-   #..         :* args  h 4  i :?  j 1    ;star args, keyword
+   #> (lambda (: a :?  b :?  :/ :?            ;positional only
+   #..         c :?  d :?                     ;normal
+   #..         e 1  f 2                       ;default
+   #..         :* args  h 4  i :?  j 1        ;star args, keyword
    #..         :** kwargs)
    #..  ;; Body.
    #..  (print (globals))
-   #..  (print (locals))                  ;side effects
-   #..  b)                                ;last value is returned
+   #..  (print (locals))                      ;side effects
+   #..  b)                                    ;last value is returned
    >>> (
    ...  lambda a,
    ...         b,
@@ -684,37 +684,37 @@ Lissp Whirlwind Tour
    <function <lambda> at 0x...>
 
 
-   #> (lambda (|*xs|))                    ;star arg
+   #> (lambda (|*xs|))                        ;star arg
    >>> (lambda *xs: ())
    <function <lambda> at 0x...>
 
-   #> (lambda (|*| |kw|))                 ;keyword only (note comma)
+   #> (lambda (|*| |kw|))                     ;keyword only (note comma)
    >>> (lambda *, kw: ())
    <function <lambda> at 0x...>
 
 
-   #> (lambda (: :* xs))                  ;Star arg must pair with star, as Python.
+   #> (lambda (: :* xs))                      ;Star arg must pair with star, as Python.
    >>> (lambda *xs: ())
    <function <lambda> at 0x...>
 
-   #> (lambda (: :* :?  kw :?))           ;Empty star arg, so kw is keyword only.
+   #> (lambda (: :* :?  kw :?))               ;Empty star arg, so kw is keyword only.
    >>> (lambda *, kw: ())
    <function <lambda> at 0x...>
 
-   #> (lambda (:* : kw :?))               ;Slid : right one pair. Still a kwonly.
+   #> (lambda (:* : kw :?))                   ;Slid : right one pair. Still a kwonly.
    >>> (lambda *, kw: ())
    <function <lambda> at 0x...>
 
-   #> (lambda (:* kw :))                  ;Implicit :? is the same. Compare.
+   #> (lambda (:* kw :))                      ;Implicit :? is the same. Compare.
    >>> (lambda *, kw: ())
    <function <lambda> at 0x...>
 
-   #> (lambda (:* kw))                    ;Kwonly! Not star arg! Final : implied.
+   #> (lambda (:* kw))                        ;Kwonly! Not star arg! Final : implied.
    >>> (lambda *, kw: ())
    <function <lambda> at 0x...>
 
 
-   #> (lambda (a b : x None  y None))     ;Normal, then positional defaults.
+   #> (lambda (a b : x None  y None))         ;Normal, then positional defaults.
    >>> (
    ...  lambda a,
    ...         b,
@@ -723,7 +723,7 @@ Lissp Whirlwind Tour
    ...     ())
    <function <lambda> at 0x...>
 
-   #> (lambda (:* a b : x None  y None))  ;Keyword only, then keyword defaults.
+   #> (lambda (:* a b : x None  y None))      ;Keyword only, then keyword defaults.
    >>> (
    ...  lambda *,
    ...         a,
@@ -734,12 +734,12 @@ Lissp Whirlwind Tour
    <function <lambda> at 0x...>
 
 
-   #> (lambda (spam eggs) eggs)           ;Simple cases look like other Lisps, but
+   #> (lambda (spam eggs) eggs)               ;Simple cases look like other Lisps, but
    >>> (lambda spam, eggs: eggs)
    <function <lambda> at 0x...>
 
-   #> ((lambda abc                        ; params not strictly required to be a tuple.
-   #..   (print c b a))                   ;There are three parameters.
+   #> ((lambda abc                            ; params need not actually be a tuple.
+   #..   (print c b a))                       ;There are three parameters.
    #.. 3 2 1)
    >>> (lambda a, b, c:
    ...     print(
@@ -753,18 +753,18 @@ Lissp Whirlwind Tour
    1 2 3
 
 
-   #> (lambda (:))                        ;Explicit : still allowed with nothing.
+   #> (lambda (:))                            ;Explicit : still allowed with nothing.
    >>> (lambda : ())
    <function <lambda> at 0x...>
 
-   #> (lambda : (print "oops"))           ;Thunk resembles Python.
+   #> (lambda : (print "oops"))               ;Thunk resembles Python.
    >>> (lambda :
    ...     print(
    ...       ('oops'))
    ... )
    <function <lambda> at 0x...>
 
-   #> ((lambda :x1 x))                    ;Control words are strings are iterable.
+   #> ((lambda :x1 x))                        ;Control words are strings are iterable.
    >>> (lambda x=1: x)()
    1
 
@@ -781,18 +781,18 @@ Lissp Whirlwind Tour
 
 
    ;; We'll be reusing this one in later sections.
-   #> (.update (globals) : + operator..add) ;Assignment. Identifier munged.
+   #> (.update (globals) : + operator..add)   ;assignment (identifier munged)
    >>> globals().update(
    ...   QzPLUS_=__import__('operator').add)
 
 
-   #> (+ 40 2)                            ;No operators. This is still a function call!
+   #> (+ 40 2)                                ;no operators (Still a function call!)
    >>> QzPLUS_(
    ...   (40),
    ...   (2))
    42
 
-   #> |40+2|                              ;Of course, this always worked. Just Python.
+   #> |40+2|                                  ;always worked, of course (just Python)
    >>> 40+2
    42
 
@@ -865,23 +865,23 @@ Lissp Whirlwind Tour
    ;;;; Templates
 
    ;; SOFT QUOTE special tag (`) starts a template
-   #> `print                              ;Automatic full qualification!
+   #> `print                                  ;Automatic full qualification!
    >>> 'builtins..print'
    'builtins..print'
 
-   #> `foo+2                              ;Not builtin. Still munges.
+   #> `foo+2                                  ;Not builtin. Still munges.
    >>> '__main__..fooQzPLUS_2'
    '__main__..fooQzPLUS_2'
 
 
-   #> `(print "Hi")                       ;Code as data. Seems to act like quote.
+   #> `(print "Hi")                           ;Code as data. Seems to act like quote.
    >>> (
    ...   'builtins..print',
    ...   "('Hi')",
    ...   )
    ('builtins..print', "('Hi')")
 
-   #> '`(print "Hi")                      ;But it's calling the "empty name".
+   #> '`(print "Hi")                          ;But it's calling the "empty name".
    >>> ('',
    ...  ':',
    ...  ':?',
@@ -903,7 +903,7 @@ Lissp Whirlwind Tour
    ...   )
    ('builtins..print', 'HI')
 
-   #> `(,'foo+2 foo+2)                    ;Interpolations not auto-qualified!
+   #> `(,'foo+2 foo+2)                        ;Interpolations not auto-qualified!
    >>> (
    ...   'fooQzPLUS_2',
    ...   '__main__..fooQzPLUS_2',
@@ -919,7 +919,7 @@ Lissp Whirlwind Tour
    ...   )
    ('builtins..print', 'a', 'b', 'c')
 
-   #> `(print (.upper "abc"))             ;Template quoting is recursive
+   #> `(print (.upper "abc"))                 ;Template quoting is recursive
    >>> (
    ...   'builtins..print',
    ...   (
@@ -929,7 +929,7 @@ Lissp Whirlwind Tour
    ...   )
    ('builtins..print', ('.upper', "('abc')"))
 
-   #> `(print ,@(.upper "abc"))           ; unless suppressed by an unquote.
+   #> `(print ,@(.upper "abc"))               ; unless suppressed by an unquote.
    >>> (
    ...   'builtins..print',
    ...   *('abc').upper(),
@@ -1007,7 +1007,7 @@ Lissp Whirlwind Tour
    ['a', 'b', 'c', 1, 2, 3]
 
 
-   #> `(0 "a" 'b)                         ;Beware of Unicode tokens and symbols.
+   #> `(0 "a" 'b)                             ;Beware of Unicode tokens and symbols.
    >>> (
    ...   (0),
    ...   "('a')",
@@ -1018,7 +1018,7 @@ Lissp Whirlwind Tour
    ...   )
    (0, "('a')", ('quote', '__main__..b'))
 
-   #> `(,0 ,"a" ,'b)                      ;Just unquote everything in data templates.
+   #> `(,0 ,"a" ,'b)                          ;Just unquote everything in data templates.
    >>> (
    ...   (0),
    ...   ('a'),
@@ -1028,7 +1028,7 @@ Lissp Whirlwind Tour
 
 
    #> (dict `((,0 ,1)
-   #..        ,@(.items (dict : spam "eggs"  foo 2)) ;dict unpacking
+   #..        ,@(.items (dict : spam "eggs"  foo 2)) ; dict unpacking
    #..        (,3 ,4)))
    >>> dict(
    ...   (
@@ -1052,7 +1052,7 @@ Lissp Whirlwind Tour
    ;;; We can use functions to to create forms for evaluation.
    ;;; This is metaprogramming: code that writes code.
 
-   #> (.update (globals)                  ;assign fills in a template to make a form.
+   #> (.update (globals)                      ;assign fills template to make a form
    #..         : assign
    #..         (lambda (key value)
    #..           `(.update (globals) : ,key ,value)))
@@ -1071,22 +1071,22 @@ Lissp Whirlwind Tour
 
 
    ;; Notice the arguments to it are quoted.
-   #> (assign 'SPAM '"eggs")              ;The result is a valid Hissp form.
+   #> (assign 'SPAM '"eggs")                  ;resulting in a valid Hissp form
    >>> assign(
    ...   'SPAM',
    ...   "('eggs')")
    ('.update', ('builtins..globals',), ':', 'SPAM', "('eggs')")
 
-   #> (hissp.compiler..readerless _)      ;Hissp can compile it,
+   #> (hissp.compiler..readerless _)          ;Hissp can compile it,
    >>> __import__('hissp.compiler',fromlist='*').readerless(
    ...   _)
    "__import__('builtins').globals().update(\n  SPAM=('eggs'))"
 
-   #> (eval _)                            ; and Python can evaluate that.
+   #> (eval _)                                ; and Python can evaluate that.
    >>> eval(
    ...   _)
 
-   #> SPAM                                ;'eggs'
+   #> SPAM                                    ;'eggs'
    >>> SPAM
    'eggs'
 
@@ -1097,14 +1097,14 @@ Lissp Whirlwind Tour
    ;;; the current module's _macro_ namespace. The REPL includes one, but
    ;;; .lissp files don't have one until you create it.
 
-   (dir)                                  ;note _macro_
+   (dir)                                   ;note _macro_
    (dir _macro_)
 
    ;;; Macros run at compile time, so they get all of their arguments
    ;;; unevaluated. The compiler inserts the resulting Hissp
    ;;; (the EXPANSION) at that point in the program.
 
-   #> (setattr _macro_ 'assign assign)    ;we can use assign as a MACRO FUNCTION
+   #> (setattr _macro_ 'assign assign)        ;we can use assign as a MACRO FUNCTION
    >>> setattr(
    ...   _macro_,
    ...   'assign',
@@ -1112,12 +1112,12 @@ Lissp Whirlwind Tour
 
 
    ;; Like special forms, macro forms look like ordinary function calls.
-   #> (assign SPAM "ham")                 ;This runs a metaprogram!
+   #> (assign SPAM "ham")                     ;This runs a metaprogram!
    >>> # assign
    ... __import__('builtins').globals().update(
    ...   SPAM=('ham'))
 
-   #> SPAM                                ;'ham'
+   #> SPAM                                    ;'ham'
    >>> SPAM
    'ham'
 
@@ -1140,13 +1140,13 @@ Lissp Whirlwind Tour
    ;;; (i.e. QzHASH_) in _macro_. Metaprograms for tagging tokens run at
    ;;; read time, but (like ') may simply return code that runs later.
 
-   #> (setattr _macro_ 'chr\# chr)        ;note \# (would be a tag token otherwise)
+   #> (setattr _macro_ 'chr\# chr)            ;note \# (would be a tag token otherwise)
    >>> setattr(
    ...   _macro_,
    ...   'chrQzHASH_',
    ...   chr)
 
-   #> 'chr#42                             ;note hard quote
+   #> 'chr#42                                 ;note hard quote
    >>> '*'
    '*'
 
@@ -1155,12 +1155,12 @@ Lissp Whirlwind Tour
    (help hissp.._macro_.define)
 
    ;; An invocation fully qualified with _macro_ is a macro form.
-   #> (hissp.._macro_.define SPAM "eggs") ;Note SPAM is not quoted.
+   #> (hissp.._macro_.define SPAM "eggs")     ;Note SPAM is not quoted.
    >>> # hissp.._macro_.define
    ... __import__('builtins').globals().update(
    ...   SPAM=('eggs'))
 
-   #> SPAM                                ;'eggs'
+   #> SPAM                                    ;'eggs'
    >>> SPAM
    'eggs'
 
@@ -1190,7 +1190,7 @@ Lissp Whirlwind Tour
    ...         )
    ...   ))
 
-   #> (triple 4)                          ;12
+   #> (triple 4)                              ;12
    >>> # triple
    ... __import__('builtins').globals()['QzPLUS_'](
    ...   (4),
@@ -1209,7 +1209,7 @@ Lissp Whirlwind Tour
    ...                      x)  [-1]
    ...                  ))
 
-   #> (triple (loud-number 14))           ;Triples the *code*, not just the *value*.
+   #> (triple (loud-number 14))               ;Triples the *code*, not just the *value*.
    >>> # triple
    ... __import__('builtins').globals()['QzPLUS_'](
    ...   loudQzH_number(
@@ -1261,7 +1261,7 @@ Lissp Whirlwind Tour
    ;; Let's try making a template to produce code like that.
    #> (define _macro_.oops-triple
    #..  (lambda (expression)
-   #..    `((lambda (: x ,expression) ;Expand to lambda call for a local.
+   #..    `((lambda (: x ,expression) ; Expand to lambda call for a local.
    #..        (+ x (+ x x))))))
    >>> # define
    ... __import__('builtins').setattr(
@@ -1289,7 +1289,7 @@ Lissp Whirlwind Tour
    ...         )
    ...   ))
 
-   #> (oops-triple 14)                    ;Oops. Templates qualify symbols!
+   #> (oops-triple 14)                        ;Oops. Templates qualify symbols!
    >>> # oopsQzH_triple
    ... (lambda __main__..x=(14):
    ...     __import__('builtins').globals()['QzPLUS_'](
@@ -1377,7 +1377,7 @@ Lissp Whirlwind Tour
    #..    (.__getitem__ ; Tuple method. Templates produce tuples.
    #..      `(,first ; Result when no args left.
    #..        (operator..add ,first (+ ,@args))) ; Otherwise recur.
-   #..      (bool args))))        ;Bools are ints, remember?
+   #..      (bool args)))) ; Bools are ints, remember?
    >>> # define
    ... __import__('builtins').setattr(
    ...   _macro_,
@@ -1491,7 +1491,7 @@ Lissp Whirlwind Tour
    ;;; dependent on Hissp (STANDALONE PROPERTY) when used correctly.
 
    ;; Three of the helpers expand macros.
-   #> (hissp..macroexpand1 '(print 1 2 3)) ;not a macro form (no change)
+   #> (hissp..macroexpand1 '(print 1 2 3))    ;not a macro form (no change)
    >>> __import__('hissp').macroexpand1(
    ...   ('print',
    ...    (1),
@@ -1499,7 +1499,7 @@ Lissp Whirlwind Tour
    ...    (3),))
    ('print', 1, 2, 3)
 
-   #> (hissp..macroexpand1 '(* 1 2 3))    ;expanded (but still a macro form)
+   #> (hissp..macroexpand1 '(* 1 2 3))        ;expanded (but still a macro form)
    >>> __import__('hissp').macroexpand1(
    ...   ('QzSTAR_',
    ...    (1),
@@ -1507,7 +1507,7 @@ Lissp Whirlwind Tour
    ...    (3),))
    ('__main__..QzMaybe_.QzSTAR_', ('operator..mul', 1, 2), 3)
 
-   #> (hissp..macroexpand '(* 1 2 3))     ;repeats while it's a macro form
+   #> (hissp..macroexpand '(* 1 2 3))         ;repeats while it's a macro form
    >>> __import__('hissp').macroexpand(
    ...   ('QzSTAR_',
    ...    (1),
@@ -1515,7 +1515,7 @@ Lissp Whirlwind Tour
    ...    (3),))
    ('operator..mul', ('operator..mul', 1, 2), 3)
 
-   #> (hissp..macroexpand '(+ 1 2 3))     ;but doesn't check subforms
+   #> (hissp..macroexpand '(+ 1 2 3))         ;but doesn't check subforms
    >>> __import__('hissp').macroexpand(
    ...   ('QzPLUS_',
    ...    (1),
@@ -1523,7 +1523,7 @@ Lissp Whirlwind Tour
    ...    (3),))
    ('operator..add', 1, ('__main__..QzMaybe_.QzPLUS_', 2, 3))
 
-   #> (hissp..macroexpand_all '(+ 1 2 3)) ;expands all macro subforms
+   #> (hissp..macroexpand_all '(+ 1 2 3))     ;expands all macro subforms
    >>> __import__('hissp').macroexpand_all(
    ...   ('QzPLUS_',
    ...    (1),
@@ -1586,7 +1586,7 @@ Lissp Whirlwind Tour
 
 
    ;; Macros only work as invocations, not arguments!
-   #> (functools..reduce * '(1 2 3 4))    ;Oops.
+   #> (functools..reduce * '(1 2 3 4))        ;Oops.
    >>> __import__('functools').reduce(
    ...   QzSTAR_,
    ...   ((1),
@@ -1597,7 +1597,7 @@ Lissp Whirlwind Tour
      ...
    NameError: name 'QzSTAR_' is not defined
 
-   #> (functools..reduce (lambda xy (* x y)) ;Invocation, not argument.
+   #> (functools..reduce (lambda xy (* x y))  ;Invocation, not argument.
    #..                   '(1 2 3 4))
    >>> __import__('functools').reduce(
    ...   (lambda x, y:
@@ -1622,7 +1622,7 @@ Lissp Whirlwind Tour
 
    #> (define _macro_.XY
    #..  (lambda (: :* body)
-   #..    `(lambda (,'X ,'Y)       ;,'X instead of $#X
+   #..    `(lambda (,'X ,'Y)                  ;,'X instead of $#X
    #..       ,body)))
    >>> # define
    ... __import__('builtins').setattr(
@@ -1640,7 +1640,7 @@ Lissp Whirlwind Tour
    ...   ))
 
 
-   #> (functools..reduce (XY * X Y)       ;Invocation, not argument!
+   #> (functools..reduce (XY * X Y)           ;Invocation, not argument!
    #..                   '(1 2 3 4))
    >>> __import__('functools').reduce(
    ...   # XY
@@ -1671,7 +1671,7 @@ Lissp Whirlwind Tour
 
 
    ;; It's possible for a macro to shadow a global. They live in different namespaces.
-   #> (+ 1 2 3 4)                         ;_macro_.+, not the global.
+   #> (+ 1 2 3 4)                             ;_macro_.+, not the global.
    >>> # QzPLUS_
    ... __import__('operator').add(
    ...   (1),
@@ -1685,7 +1685,7 @@ Lissp Whirlwind Tour
    ...       (4))))
    10
 
-   #> (functools..reduce + '(1 2 3 4))    ;Global function, not the macro!
+   #> (functools..reduce + '(1 2 3 4))        ;Global function, not the macro!
    >>> __import__('functools').reduce(
    ...   QzPLUS_,
    ...   ((1),
@@ -1695,8 +1695,8 @@ Lissp Whirlwind Tour
    10
 
 
-   (dir)                               ;Has QzPLUS_, but not QzSTAR_.
-   (dir _macro_)                       ;Has both.
+   (dir)                                   ;Has QzPLUS_, but not QzSTAR_.
+   (dir _macro_)                           ;Has both.
 
    ;; Notice the qualifier on sep. Qualifying a keyword doesn't make sense.
    #> (define _macro_.p123
@@ -1767,7 +1767,7 @@ Lissp Whirlwind Tour
    Hello World!
 
 
-   #> spam..x                             ;Compiled modules are cached.
+   #> spam..x                                 ;Compiled modules are cached.
    >>> __import__('spam').x
    42
 
@@ -1775,14 +1775,14 @@ Lissp Whirlwind Tour
    >>> __import__('eggs')
    <module 'eggs' from ...>
 
-   #> (importlib..reload spam.)           ;Side effects again on .py reload.
+   #> (importlib..reload spam.)               ;Side effects again on .py reload.
    >>> __import__('importlib').reload(
    ...   __import__('spam'))
    Hello from spam!
    <module 'spam' from ...>
 
 
-   #> (any (map (lambda f (os..remove f)) ;Cleanup.
+   #> (any (map (lambda f (os..remove f))     ;Cleanup.
    #..     '(eggs.lissp spam.lissp spam.py eggs.py)))
    >>> any(
    ...   map(

--- a/docs/primer.rst
+++ b/docs/primer.rst
@@ -2133,7 +2133,7 @@ But there are times when a function will not do:
    ...   ))
 
    #> ((lambda (%)
-   #..   (print (.upper %)))              ;This lambda expression
+   #..   (print (.upper %)))                  ;This lambda expression
    #.. "q")
    >>> (lambda QzPCENT_:
    ...     print(
@@ -2142,7 +2142,7 @@ But there are times when a function will not do:
    ...   ('q'))
    Q
 
-   #> ((% print (.upper %))               ; can now be abbreviated.
+   #> ((% print (.upper %))                   ; can now be abbreviated.
    #.. "q")
    >>> # QzPCENT_
    ... (lambda QzPCENT_:

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -255,13 +255,13 @@ Go past the parent's opening bracket, not the sibling's:
 .. code-block:: Lissp
 
    (a (b c))
-   x                                      ;(a (b c)) is sibling
+   x                                       ;(a (b c)) is sibling
 
    (a (b c)
-      x)                                  ;(a is parent, (b c) is sibling
+      x)                                   ;(a is parent, (b c) is sibling
 
    (a (b c
-         x))                              ;(b is parent, c is sibling
+         x))                               ;(b is parent, c is sibling
 
 Even after deleting the trails, you can tell where the ``x`` belongs. ::
 
@@ -298,10 +298,10 @@ You might not pass the head *atom* in some alignment styles:
 .. code-block:: Lissp
 
    (foo (bar x)
-     body)                                ;(foo is parent, (bar x) is special sibling
+     body)                                 ;(foo is parent, (bar x) is special sibling
 
    (foo (bar x
-          body))                          ;(bar is parent, x is special sibling
+          body))                           ;(bar is parent, x is special sibling
 
 We can still unambiguously reconstruct the trails from the indent. ::
 
@@ -441,62 +441,62 @@ Your code should look like these examples, recursively applied to subforms:
 
 .. code-block:: Lissp
 
-   '(data1 data2 data3)                   ;Treat all data items the same.
+   '(data1 data2 data3)                    ;Treat all data items the same.
 
-   '(data1                                ;Line break for one, break for all.
-     data2                                ;Items start on the same column.
-     data3)                               ;Could've all fit on 1 line. (Just an example.)
+   '(data1                                 ;Line break for one, break for all.
+     data2                                 ;Items start on the same column.
+     data3)                                ;Could've all fit on 1 line. (Just an example.)
 
-   '(                                     ;This is better for linewise version control.
-     data1                                ; Probably only worth it for a lot more than 3,
-     data2                                ; or if it changes frequently.
-     data3                                ; Use this style sparingly.
-     _#/)                                 ;Trails NEVER get their own line.
-                                          ; But you can hold it open with a discarded item.
-                                          ; This XML-style / doorstop is the norm in Lissp.
+   '(                                      ;This is better for linewise version control.
+     data1                                 ; Probably only worth it for a lot more than 3,
+     data2                                 ; or if it changes frequently.
+     data3                                 ; Use this style sparingly.
+     _#/)                                  ;Trails NEVER get their own line.
+                                           ; But you can hold it open with a discarded item.
+                                           ; This XML-style / doorstop is the norm in Lissp.
 
-   (function arg1 arg2 arg3)              ;Typical for calls that fit on one line.
+   (function arg1 arg2 arg3)               ;Typical for calls that fit on one line.
 
    ;; Also common. The function name is separate from the arguments in this style.
-   (function arg1                         ;Break for one, break for all.
-             arg2                         ;Args start on the same column.
+   (function arg1                          ;Break for one, break for all.
+             arg2                          ;Args start on the same column.
              arg3)
 
    ;; The previous alignment is preferred, but this is OK if a line would be too long.
    (function
-    arg1                                  ;Just like data.
+    arg1                                   ;Just like data.
     arg2
     arg3)
 
    ((lambda (a b c)
       (reticulate a)
       (frobnicate a b c))
-    arg1                                  ;The "not past the sibling" rule is absolute.
-    arg2                                  ; Not even one space past the (lambda.
+    arg1                                   ;The "not past the sibling" rule is absolute.
+    arg2                                   ; Not even one space past the (lambda.
     arg3)
 
-   (function                              ;Acceptable, but unusual.
+   (function                               ;Acceptable, but unusual.
     arg1 arg2 arg3)
 
    ((lambda (a b c)
       (print c b a))
-    arg1 arg2 arg3)                       ;Break for all args or for none.
+    arg1 arg2 arg3)                        ;Break for all args or for none.
 
    ;; One extra space between pairs.
    (function arg1 arg2 : kw1 kwarg1  kw2 kwarg2  kw3 kwarg3)
 
    ;; This might make the reason a bit more obvious:
-   (% 1 0 2 9 3 8 4 7 5 6)                ;Bad. Can't tell keys from values.
+   (% 1 0 2 9 3 8 4 7 5 6)                 ;Bad. Can't tell keys from values.
 
-   (% 1 0  2 9  3 8  4 7  5 6)            ;Preferred. Group implied pairs.
+   (% 1 0  2 9  3 8  4 7  5 6)             ;Preferred. Group implied pairs.
 
-   (% 1 0                                 ;OK, but could have fit on one line.
+   (% 1 0                                  ;OK, but could have fit on one line.
       2 9
       3 8
       4 7
       5 6)
 
-   (%                                     ;Also OK.
+   (%                                      ;Also OK.
     1 0
     2 9
     3 8
@@ -504,14 +504,14 @@ Your code should look like these examples, recursively applied to subforms:
     5 6)
 
    (function arg1 arg2
-             : kw1 kwarg1  kw2 kwarg2)    ;Breaking groups, not args.
+             : kw1 kwarg1  kw2 kwarg2)     ;Breaking groups, not args.
 
    (function arg1
              arg2
-             : kw1 kwarg1                 ;The : starts the line.
-             kw2 kwarg2)                  ;Break for args, but pairs stay together.
+             : kw1 kwarg1                  ;The : starts the line.
+             kw2 kwarg2)                   ;Break for args, but pairs stay together.
 
-   (function : kw1 kwarg1                 ;The : starts the "line". Sort of.
+   (function : kw1 kwarg1                  ;The : starts the "line". Sort of.
              kw2 kwarg2)
 
    ;; The previous alignment is preferred, but this is OK if the line would be too long.
@@ -521,39 +521,39 @@ Your code should look like these examples, recursively applied to subforms:
     :
     kw1
     kwarg1
-    ;;                                    ;Break for everything, and ;; line to separate pairs.
+    ;;                                     ;Break for everything, and ;; line to separate pairs.
     kw2
     kwarg2)
 
-   (dict : a 1  b 2  c 3)                 ;Preferred
+   (dict : a 1  b 2  c 3)                  ;Preferred
 
-   (dict : a 1                            ;Standard, but could have fit on one line.
+   (dict : a 1                             ;Standard, but could have fit on one line.
          b 2
          c 3)
 
-   (dict : a 1                            ;Acceptable if : is first, but be consistent.
-           b 2                            ;Note the alignment with the previous line.
+   (dict : a 1                             ;Acceptable if : is first, but be consistent.
+           b 2                             ;Note the alignment with the previous line.
            c 3)
 
-   (dict :                                ;Acceptable, especially for data.
-    a 1                                   ; May be better for linewise version control.
-    b 2                                   ; Use this style sparingly.
+   (dict :                                 ;Acceptable, especially for data.
+    a 1                                    ; May be better for linewise version control.
+    b 2                                    ; Use this style sparingly.
     c 3
     _#/)
 
-   (function arg1                         ;Bad. : not first. Weird extra levels.
+   (function arg1                          ;Bad. : not first. Weird extra levels.
              arg2
              : kw1 kwarg1
                kw2 kwarg2
 
-   (function arg1 arg2                    ;Bad. : not first. Weird extra levels.
+   (function arg1 arg2                     ;Bad. : not first. Weird extra levels.
              : kw1 kwarg1
                kw2 kwarg2
 
-   (macro special1 special2 special3      ;Macros can have their own alignment rules.
-     body1                                ; Simpler macros may look the same as functions.
-     body2                                ; Special/body is common. Lambda is also like this.
-     body3)                               ; Body is indented 1 extra space.
+   (macro special1 special2 special3       ;Macros can have their own alignment rules.
+     body1                                 ; Simpler macros may look the same as functions.
+     body2                                 ; Special/body is common. Lambda is also like this.
+     body3)                                ; Body is indented 1 extra space.
 
    (macro special1 body1)
 
@@ -595,11 +595,11 @@ Your code should look like these examples, recursively applied to subforms:
      body)
 
    ;; Parameter groups are separated by lines. Pairs are separated by an extra space.
-   (lambda (a b :/                        ;positional-only group
-            c d                           ;normal group
-            : e 1  f 2                    ;colon group
-            :* args  h 4  i :?  j 1       ;star group
-            :** kwargs)                   ;kwargs
+   (lambda (a b :/                         ;positional-only group
+            c d                            ;normal group
+            : e 1  f 2                     ;colon group
+            :* args  h 4  i :?  j 1        ;star group
+            :** kwargs)                    ;kwargs
      body)
 
 Readerless style is similar:
@@ -673,18 +673,18 @@ because the string's structure is more important for legibility than the tuple's
 
 .. code-block:: Lissp
 
-   (enjoin                                ;Preferred.
+   (enjoin                                 ;Preferred.
      "Weather in "location" for "date" will be "weather"
     with a "percent"% chance of rain.")
 
-   (enjoin "Weather in "                  ;OK.
+   (enjoin "Weather in "                   ;OK.
            location
            " for "
            date
            " will be "
            weather
            "
-     with a "                             ;OK, but would look better with \n.
+     with a "                              ;OK, but would look better with \n.
            percent
            "% chance of rain.")
 
@@ -693,23 +693,23 @@ not just the fact that it's a call:
 
 .. code-block:: Lissp
 
-   (enter (wrap 'A)                       ;Stacked context managers.
-    enter (wrap 'B)                       ; Note pairs.
-    enter (wrap 'C)                       ; `enter` is from the prelude.
+   (enter (wrap 'A)                        ;Stacked context managers.
+    enter (wrap 'B)                        ; Note pairs.
+    enter (wrap 'C)                        ; `enter` is from the prelude.
     (lambda abc (print a b c)))
 
    (engarde `(,FloatingPointError ,ZeroDivisionError) ; engarde from prelude
             print
-            truediv 6 0)                  ;(truediv 6 0) is a deferred call, so groups.
+            truediv 6 0)                   ;(truediv 6 0) is a deferred call, so groups.
 
-   (.update (globals) :                   ;OK. : on wrong side, but easier
-    + operator..add                       ; for linewise version control.
-    - operator..sub                       ; Sometimes worth it, but
-    * operator..mul                       ; use this style sparingly.
+   (.update (globals) :                    ;OK. : on wrong side, but easier
+    + operator..add                        ; for linewise version control.
+    - operator..sub                        ; Sometimes worth it, but
+    * operator..mul                        ; use this style sparingly.
     / operator..truediv
-    _#/)                                  ;Doorstop holding ) on this line.
+    _#/)                                   ;Doorstop holding ) on this line.
 
-   (.update (globals)                     ;Preferred. Standard style.
+   (.update (globals)                      ;Preferred. Standard style.
             : + operator..add
             - operator..sub
             * operator..mul
@@ -938,17 +938,17 @@ Functional tests make good debugging entry points.
           special4 ; entirely separate comment about special4 line
      body1
      ;; comment about body2
-     body2                                ;Margin comment
-     body3)                               ; continuation thereof,
-                                          ; and more continuation on its own line.
+     body2                                 ;Margin comment
+     body3)                                ; continuation thereof,
+                                           ; and more continuation on its own line.
 
 Complete sentences should start with a capital letter and end with
 a punctuation mark (typically a full stop or question mark).
 Separate sentences with a single space.
 Short comments need not be complete sentences.
 
-Inline Comments ; X
-+++++++++++++++++++
+``Inline ; comments``
++++++++++++++++++++++
 
 Comments about a line begin with one semicolon and a space ``; x``,
 starting **one** space after the code.
@@ -967,8 +967,8 @@ Avoid obtuse abbreviations just to make a comment fit in line.
 When a comment needs to be longer to be clear,
 use a different comment style instead.
 
-Margin Comments ;X
-++++++++++++++++++
+``Margin          ;comments``
++++++++++++++++++++++++++++++
 
 Margin comments begin with one semicolon ``;x``.
 The semicolon must be aligned with spaces to rest on column 40,
@@ -1027,8 +1027,8 @@ You may instead hold open the bracket with a :term:`doorstop`,
 convert the comment to a discarded string ``_#"NB foo")``,
 or (if appropriate) use a form/group ``;;`` comment above the item, as described below.
 
-;; Form/Group Comments
-++++++++++++++++++++++
+``;; form/group comments``
+++++++++++++++++++++++++++
 
 Comments about the next :term:`form` (or group)
 begin with two semicolons and a space ``;; x``,
@@ -1044,8 +1044,8 @@ or use the discard macro ``_#`` to comment out code structurally.
 
 Prefer class and function docstrings over ``;;`` comments where applicable.
 
-;;; Top-Level Comments
-++++++++++++++++++++++
+*;;; top-level comments*
+++++++++++++++++++++++++
 
 Top-level commentary lines not attached to any :term:`form` in particular
 begin with three semicolons and a space ``;;; Foo Bar``.
@@ -1067,8 +1067,8 @@ Remember that a `<# <QzLT_QzHASH_>`
 applied to a comment block compiles to a string literal,
 which can be a docstring.
 
-;;;; Headings
-+++++++++++++
+**;;;; Headings**
++++++++++++++++++
 
 Headings begin with four semicolons and a space ``;;;; Foo Bar``,
 fit on one line,
@@ -1158,8 +1158,8 @@ you will not have any undecorated H6's at all.)
 Multiple H1s might be acceptable for large projects distributed as a single concatenated
 Lissp file, where they'd head what would normally be modules in separate files.
 
-_#_#_#The Discard Macro
-+++++++++++++++++++++++
+``_#_#_#The Discard Macro``
++++++++++++++++++++++++++++
 
 The discard macro ``_#`` applied to a :term:`Unicode token`
 is acceptable for long block comments at the top level.
@@ -1213,8 +1213,8 @@ within a line, to indicate greater separation than the extra spaces.
 These are also used in the :term:`doorstop`
 ``_#/`` used to "hold open" a trail of brackets.
 
-<#;Docstrings
-+++++++++++++
+``<#;Docstrings``
++++++++++++++++++
 
 Prefer docstrings over semicolon comments where applicable.
 Quality over quantity,
@@ -1342,23 +1342,23 @@ as the :term:`params` when they'd each be one (non-munging) character:
 
 .. code-block:: Lissp
 
-   (lambda abc (print c b a))             ;Preferred
+   (lambda abc (print c b a))              ;Preferred
 
-   (lambda (a b c)                        ;OK
+   (lambda (a b c)                         ;OK
      (print c b a))
 
    ;;; This goes for macro arguments directly used as params too.
 
-   (let-from abc 'XYZ (print c b a))      ;Preferred
+   (let-from abc 'XYZ (print c b a))       ;Preferred
 
-   (let-from (a b c)                      ;OK
+   (let-from (a b c)                       ;OK
              'XYZ
      (print c b a))
 
-   (any*map kv (.items (dict : a 1  b 2)) ;Preferred
+   (any*map kv (.items (dict : a 1  b 2))  ;Preferred
      (print k v))
 
-   (any*map (k v)                         ;OK
+   (any*map (k v)                          ;OK
             (.items (dict : a 1  b 2))
      (print k v))
 
@@ -1616,36 +1616,36 @@ For an argument, i.e., other method calls, prefer ``.foo bar``:
 
 .. code-block:: Lissp
 
-   (hissp.._macro_.define greeting "hi")  ;Compile-time macroexpansion
+   (hissp.._macro_.define greeting "hi")   ;Compile-time macroexpansion
    (.define hissp.._macro_ 'greeting '"hi") ;Run-time expansion.
 
    ;;;; Arguments
 
-   (.upper "hi")                          ;Preferred.
-   ("hi".upper)                           ;SyntaxError.
-   (-> "hi".upper)                        ;Works, but overcomplicating it.
+   (.upper "hi")                           ;Preferred.
+   ("hi".upper)                            ;SyntaxError.
+   (-> "hi".upper)                         ;Works, but overcomplicating it.
 
-   (.upper greeting)                      ;Preferred.
-   (greeting.upper)                       ;Usually bad. Hides first argument from macros,
-                                          ; but you may want that sometimes.
+   (.upper greeting)                       ;Preferred.
+   (greeting.upper)                        ;Usually bad. Hides first argument from macros,
+                                           ; but you may want that sometimes.
 
    ;;;; Namespaces
 
-   (tkinter..Tk)                          ;Preferred. Fully-qualified name.
-   (.Tk tkinter.)                         ;Bad. Not really a method call.
+   (tkinter..Tk)                           ;Preferred. Fully-qualified name.
+   (.Tk tkinter.)                          ;Bad. Not really a method call.
 
    ;;;; Kind of Both
 
-   (self.foo spam eggs)                   ;Preferred.
-   (.foo self spam eggs)                  ;OK. Consider for doto, ->, etc.
+   (self.foo spam eggs)                    ;Preferred.
+   (.foo self spam eggs)                   ;OK. Consider for doto, ->, etc.
 
-   (cls.foo spam eggs)                    ;Preferred.
-   (.foo cls spam eggs)                   ;OK.
+   (cls.foo spam eggs)                     ;Preferred.
+   (.foo cls spam eggs)                    ;OK.
 
    ;; `self` as namespace, `self.accumulator` as first argument.
-   (.append self.accumulator x)           ;Preferred. Good use of both.
+   (.append self.accumulator x)            ;Preferred. Good use of both.
 
-   (self.accumulator.append x)            ;Usually bad. Hides first argument.
+   (self.accumulator.append x)             ;Usually bad. Hides first argument.
 
    ;; Bad. This does happen to be valid syntactically, but is probably
    ;; confusing in most cases. The namespace is `self`, but that looks
@@ -1668,7 +1668,7 @@ but don't overdo it:
 
    (lambda (x) (print "Hi" x) (print "Bye" x)) ;OK.
 
-   (lambda (x)                            ;Preferred.
+   (lambda (x)                             ;Preferred.
      (print "Hi" x)
      (print "Bye" x))
 
@@ -1682,10 +1682,10 @@ then the tree structure is clear from the indents:
 
    (print (/ (sum xs) (len xs)) "on average.") ;Bad. Internal ))'s.
 
-   (print (/ (sum xs) (len xs))           ;OK. One internal ) though.
+   (print (/ (sum xs) (len xs))            ;OK. One internal ) though.
           "on average.")
 
-   (print (/ (sum xs)                     ;Preferred. )'s end the line.
+   (print (/ (sum xs)                      ;Preferred. )'s end the line.
              (len xs))
           "on average.")
 
@@ -1701,7 +1701,7 @@ for example:
 
 .. code-block:: Lissp
 
-   (lambda (x)                            ;Preferred.
+   (lambda (x)                             ;Preferred.
      (cond (lt x 0) (print "negative")
            (eq x 0) (print "zero")
            (gt x 0) (print "positive")
@@ -1712,12 +1712,12 @@ even in an implied group:
 
 .. code-block:: Lissp
 
-   (defun compare (xs ys)                 ;Bad. Internal ))'s are hard to read.
+   (defun compare (xs ys)                  ;Bad. Internal ))'s are hard to read.
      (cond (lt (len xs) (len ys)) (print "<")
            (gt (len xs) (len ys)) (print ">")
            :else (print "0"))))
 
-   (defun compare (xs ys)                 ;Bad. No groups. Can't tell if from then.
+   (defun compare (xs ys)                  ;Bad. No groups. Can't tell if from then.
      (cond (lt (len xs) (len ys))
            (print "<")
            (gt (len xs) (len ys))
@@ -1725,22 +1725,22 @@ even in an implied group:
            :else
            (print "0"))))
 
-   (defun compare (xs ys)                 ;OK. Use discard comments sparingly.
+   (defun compare (xs ys)                  ;OK. Use discard comments sparingly.
      (cond (lt (len xs) (len ys))
            (print "<")
            _#:elif->(gt (len xs) (len ys)) ;Unambiguous, but unaligned.
            (print ">")
            :else (print "0")))) ; No internal ), so 1 line is OK. Still grouped.
 
-   (defun compare (xs ys)                 ;OK. Better.
+   (defun compare (xs ys)                  ;OK. Better.
      (cond (lt (len xs) (len ys))
            (print "<")
-           ;; else if                     ;The styling comment is not optional;
-           (gt (len xs) (len ys))         ; it's needed for separating groups.
+           ;; else if                      ;The styling comment is not optional;
+           (gt (len xs) (len ys))          ; it's needed for separating groups.
            (print ">")
            :else (print "0"))))
 
-   (defun compare (xs ys)                 ;Preferred. Keep cond simple.
+   (defun compare (xs ys)                  ;Preferred. Keep cond simple.
      (let (lxs (len xs)
            lys (len ys))
        (cond (lt lxs lys) (print "<")

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -111,7 +111,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   .. code-block:: REPL
 
      #> (any-map c 'ab
-     #..  (if-else (op#eq c 'b)            ;ternary conditional
+     #..  (if-else (op#eq c 'b)                 ;ternary conditional
      #..    (print 'Yes)
      #..    (print 'No)))
      >>> # anyQzH_map
@@ -150,7 +150,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
 
   .. code-block:: REPL
 
-     #> (print (progn (print 1)             ;Sequence for side effects, eval to last.
+     #> (print (progn (print 1)                 ;Sequence for side effects, eval to last.
      #..              (print 2)
      #..              3))
      >>> print(
@@ -175,13 +175,13 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
 
   .. code-block:: REPL
 
-     #> (let (x 'a                          ;Create locals.
-     #..      y 'b)                         ;Any number of pairs.
+     #> (let (x 'a                              ;Create locals.
+     #..      y 'b)                             ;Any number of pairs.
      #..  (print x y)
      #..  (let (x 'x
-     #..        y (op#concat x x))          ;Not in scope until body.
-     #..    (print x y))                    ;Outer variables shadowed.
-     #..  (print x y))                      ;Inner went out of scope.
+     #..        y (op#concat x x))              ;Not in scope until body.
+     #..    (print x y))                        ;Outer variables shadowed.
+     #..  (print x y))                          ;Inner went out of scope.
      >>> # let
      ... (
      ...  lambda x='a',
@@ -247,9 +247,9 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      ...   C='D')
      {'A': 'B', 'C': 'D'}
 
-     #> (let*from ((ab cd) (.items _)    ;Nested let-froms.
-     #..           (a b) ab              ;Unpacks first item ('A', 'B')
-     #..           (c d) cd)             ;Unpacks second item ('C', 'D')
+     #> (let*from ((ab cd) (.items _)           ;Nested let-froms.
+     #..           (a b) ab                     ;Unpacks first item ('A', 'B')
+     #..           (c d) cd)                    ;Unpacks second item ('C', 'D')
      #..  (print a b c d))
      >>> # letQzSTAR_from
      ... # hissp.macros.._macro_.letQzH_from
@@ -276,8 +276,8 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
      A B C D
 
 
-     #> (let*from ((ab cd) (.items _)    ;Fewer stack frames.
-     #..           (a b c d) `(,@ab ,@cd)) ;Leveraging ,@ splicing.
+     #> (let*from ((ab cd) (.items _)           ;Fewer stack frames.
+     #..           (a b c d) `(,@ab ,@cd))      ;Leveraging ,@ splicing.
      #..  (print a b c d))
      >>> # letQzSTAR_from
      ... # hissp.macros.._macro_.letQzH_from
@@ -1177,7 +1177,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (define first &#!#0)              ;Gets an item by index.
+  ;;    #> (define first &#!#0)                    ;Gets an item by index.
   ;;    >>> # define
   ;;    ... __import__('builtins').globals().update(
   ;;    ...   first=__import__('functools').partial(
@@ -1190,7 +1190,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    ...   ('abc'))
   ;;    'a'
   ;;
-  ;;    #> !##(slice None None -1) "abc"     ;Slicing without injection.
+  ;;    #> !##(slice None None -1) "abc"           ;Slicing without injection.
   ;;    >>> __import__('operator').itemgetter(
   ;;    ...   slice(
   ;;    ...     None,
@@ -1199,7 +1199,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    ...   ('abc'))
   ;;    'cba'
   ;;
-  ;;    #> !##'+ (dict : foo 2  + 1)         ;These also work on dicts.
+  ;;    #> !##'+ (dict : foo 2  + 1)               ;These also work on dicts.
   ;;    >>> __import__('operator').itemgetter(
   ;;    ...   'QzPLUS_')(
   ;;    ...   dict(
@@ -1207,7 +1207,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    ...     QzPLUS_=(1)))
   ;;    1
   ;;
-  ;;    #> (-> '(foo bar) !#1 .upper !#1)    ;Unary compatible with ->.
+  ;;    #> (-> '(foo bar) !#1 .upper !#1)          ;Unary compatible with ->.
   ;;    >>> # QzH_QzGT_
   ;;    ... __import__('operator').itemgetter(
   ;;    ...   (1))(
@@ -1906,7 +1906,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;; .. code-block:: REPL
   ;;
   ;;    #> (any-map x (@ -0.6 -0.0 42.0 math..nan)
-  ;;    #..  (cond (op#lt x 0) (print :Negative) ;if-else cascade
+  ;;    #..  (cond (op#lt x 0) (print :Negative)   ;if-else cascade
   ;;    #..        (op#eq x 0) (print :Zero)
   ;;    #..        (op#gt x 0) (print :Positive)
   ;;    #..        :else (print :Not-a-Number)))
@@ -1985,7 +1985,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (any-map index (range 1 11)         ;Imperative loop with break.
+  ;;    #> (any-map index (range 1 11)             ;Imperative loop with break.
   ;;    #..  (print index : end :)
   ;;    #..  (not (op#mod index 7)))
   ;;    >>> # anyQzH_map
@@ -2021,7 +2021,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (any*map (i c) (enumerate 'abc 1)  ;As any-map, but with starmap.
+  ;;    #> (any*map (i c) (enumerate 'abc 1)  ; As any-map, but with starmap.
   ;;    #..  (print (op#mul i c)))
   ;;    >>> # anyQzSTAR_map
   ;;    ... __import__('builtins').any(
@@ -2061,7 +2061,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (loop-from x '(3)                   ;Unpacks as let-from.
+  ;;    #> (loop-from x '(3)                       ;Unpacks as let-from.
   ;;    #..  (when x
   ;;    #..    (print x)
   ;;    #..    (recur-from (@ (op#sub x 1)))))
@@ -2244,7 +2244,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (throw Exception)                   ;Raise exception objects or classes.
+  ;;    #> (throw Exception)                       ;Raise exception objects or classes.
   ;;    >>> # throw
   ;;    ... # hissp.macros.._macro_.throwQzSTAR_
   ;;    ... (lambda g:g.close()or g.throw)(c for c in'')(
@@ -2276,7 +2276,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (throw-from Exception (Exception 'message)) ;Explicit chaining.
+  ;;    #> (throw-from Exception (Exception 'message)) ; Explicit chaining.
   ;;    #..
   ;;    >>> # throwQzH_from
   ;;    ... # hissp.macros.._macro_.throwQzSTAR_
@@ -2327,7 +2327,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (print (prog1 0                     ;Side effects in sequence. Eval to first.
+  ;;    #> (print (prog1 0                         ;Side effects in sequence. Eval to first.
   ;;    #..         (print 1)
   ;;    #..         (print 2)))
   ;;    >>> print(
@@ -2348,8 +2348,8 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (prog1                              ;Side effects in sequence. Eval to first.
-  ;;    #..  (progn (print 1)                  ;Side effects in sequence. Eval to last.
+  ;;    #> (prog1                                  ;Side effects in sequence. Eval to first.
+  ;;    #..  (progn (print 1)                      ;Side effects in sequence. Eval to last.
   ;;    #..         3)
   ;;    #..  (print 2))
   ;;    >>> # prog1
@@ -2586,7 +2586,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (# 1 :* (@ 1 2 3) 4)                ;Set, with unpacking.
+  ;;    #> (# 1 :* (@ 1 2 3) 4)                    ;Set, with unpacking.
   ;;    >>> # QzHASH_
   ;;    ... (lambda *xs: {*xs})(
   ;;    ...   (1),
@@ -2617,7 +2617,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (% 1 2  :** (dict : x 3  y 4)  5 6) ;Dict, with mapping unpacking.
+  ;;    #> (% 1 2  :** (dict : x 3  y 4)  5 6) ; Dict, with mapping unpacking.
   ;;    >>> # QzPCENT_
   ;;    ... (lambda x0, x1, x3, x4, x5: {x0:x1,**x3,x4:x5})(
   ;;    ...   (1),
@@ -2768,8 +2768,8 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;; .. code-block:: REPL
   ;;
   ;;    #> (engarde `(,FloatingPointError ,ZeroDivisionError) ;two targets
-  ;;    #..         (lambda e (print "Oops!") e)    ;handler (returns exception)
-  ;;    #..         truediv 6 0)                    ;calls it on your behalf
+  ;;    #..         (lambda e (print "Oops!") e)   ;handler (returns exception)
+  ;;    #..         truediv 6 0)                   ;calls it on your behalf
   ;;    >>> engarde(
   ;;    ...   (
   ;;    ...     FloatingPointError,
@@ -2804,11 +2804,11 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    ...   (2))
   ;;    3.0
   ;;
-  ;;    #> (engarde Exception                       ;The stacked outer engarde
+  ;;    #> (engarde Exception                      ;The stacked outer engarde
   ;;    #.. print
-  ;;    #.. engarde ZeroDivisionError               ; calls the inner.
+  ;;    #.. engarde ZeroDivisionError              ; calls the inner.
   ;;    #.. (lambda e (print "It means what you want it to mean."))
-  ;;    #.. truediv "6" 0)                          ;Try variations.
+  ;;    #.. truediv "6" 0)                         ;Try variations.
   ;;    >>> engarde(
   ;;    ...   Exception,
   ;;    ...   print,
@@ -3135,7 +3135,7 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
   ;;    #..     (Ensue (lambda (step)
   ;;    #..              (attach step :
   ;;    #..                Y None
-  ;;    #..                X ZeroDivisionError) ;X for eXcept (can be a tuple).
+  ;;    #..                X ZeroDivisionError) ; X for eXcept (can be a tuple).
   ;;    #..              (Ensue (lambda (step)
   ;;    #..                       (print "Caught a" step.sent))))))))
   ;;    >>> # define


### PR DESCRIPTION
Also fix margin comment alignment in Whirlwind Tour. Might need to check Style Guide too.