### PR TITLE
Clean up remaining Python 3.8 references

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Python—Syntactic macro metaprogramming with full access to the Python ecosyste
 <!-- markdown-toc end -->
 
 # Installation
-Hissp requires Python 3.8+.
+Hissp requires Python 3.10+.
 
 Install the latest PyPI release with
 ```
@@ -619,8 +619,8 @@ This gives Hissp a massive advantage over other Lisps with less selection.
 If you don't care to work with the Python ecosystem,
 perhaps Hissp is not the Lisp for you.
 
-Note that the Hissp compiler is written in Python 3.8,
-and the bundled macros assume at least that level.
+Note that the Hissp compiler is currently written for Python 3.10,
+and the bundled macros may assume at least that level.
 (Supporting older versions is not a goal,
 because that would complicate the compiler.
 This may limit the available libraries.)

--- a/docs/primer.rst
+++ b/docs/primer.rst
@@ -45,7 +45,7 @@ or the `Hissp community chat <https://gitter.im/hissp-lang/community>`_.
 Installation
 ============
 
-Hissp requires Python 3.8+ and has no other dependencies.
+Hissp requires Python 3.10+ and has no other dependencies.
 
 Confirm your Python version with
 

--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,7 @@ setuptools.setup(
         "": ["*.lissp"]
     },  # If any package contains *.lissp files, include them.
     package_dir={"": "../src"},
-    python_requires=">=3.8",
+    python_requires=">=3.10",
     entry_points={"console_scripts": ["lissp=hissp.__main__:main"]},
 )
 # Build dist and install:


### PR DESCRIPTION
We're on 3.10 now. #268 didn't quite finish #261.

This fixes some misleading docs and the `python_requires` field in `setup.py`. That should be all of it now.

I have separate TODOs for upgrading doc and test dependencies to eliminate their depreciation warnings which popped up after the 3.10 upgrade, but the package release itself doesn't have dependencies, so fixing those isn't a blocker.