### PR TITLE
GitHub `.lissp` syntax highlighting

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# This configuration file is part of the Hissp source code repository,
+# copyright 2025 Matthew Egan Odendahl
+# SPDX-License-Identifier: Apache-2.0
+*.lissp linguist-language=lisp linguist-vendored

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -1,5 +1,5 @@
 # This configuration file is part of the Hissp source code repository,
-# copyright 2019, 2021, 2022, 2024 Matthew Egan Odendahl
+# copyright 2019, 2021, 2022, 2024, 2025 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
 name: Test package
 
@@ -15,12 +15,12 @@ jobs:
       uses: actions/checkout@v2
     - name: Lint with black
       uses: psf/black@stable
-    - name: Set up Python 3.10.15
+    - name: Set up Python 3.10.18
       uses: actions/setup-python@v1
       with:
-        python-version: 3.10.15
+        python-version: 3.10.18
     - name: Cache pip
-      uses: actions/cache@v1
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements-dev.txt') }}

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -190,8 +190,8 @@ class Compiler:
         """Compile `call`, `macro`, or `special` forms."""
         match form:
             case [["lambda", params, *body] as head] if (
-                is_node(head) and not self.parameters(params)
-            ):
+                is_node(head)
+            ) and not self.parameters(params):
                 return self.body(body)  # progn optimization
             case head, *_ if is_str(head):
                 return self.special(form)

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -75,7 +75,7 @@ class TestCompileGeneral(TestCase):
         self.assertIn(
             """\
             # ZeroDivisionError: division by zero
-            #\N{space}
+            #\N{SPACE}
 
             print(
               'oops')"""


### PR DESCRIPTION
The new `.gitattributes` instructs GitHub to highlight the `.lissp` files as Common Lisp, which (by design) should be close enough.

Also fixes a few issues in the pipeline for dependencies that changed out from under it.