### PR TITLE
Sentinel alias

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -61,7 +61,6 @@ jobs:
         # TODO: try upgrading libraries affected by deprecations.
         PYTHONWARNINGS: error,default:SelectableGroups:DeprecationWarning:hypothesis.entry_points,default:A private pytest:DeprecationWarning:sybil.integration.pytest
       run: |
-        python -c "import tests"  # Compiles hissp.basic on package import.
         pytest -p no:cacheprovider -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
     - name: Codecov
       uses: codecov/codecov-action@v1.0.4

--- a/conftest.py
+++ b/conftest.py
@@ -7,9 +7,16 @@ from difflib import context_diff
 from doctest import ELLIPSIS
 from fnmatch import fnmatch
 from textwrap import indent
+from unittest.mock import patch
 
 from sybil import Sybil
 from sybil.parsers.doctest import DocTestParser
+
+# Ensures we're testing the current version.
+with patch.dict("sys.modules"):
+    import hissp
+
+    hissp.transpile(hissp.__package__, "macros")
 
 from hissp.reader import Lissp
 

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1207,6 +1207,8 @@ See `hissp.macros`.
 (alias pl pathlib.)
 (alias tw textwrap.)
 
+(alias \: mk#sentinel)
+
 (alias H hissp.)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,13 +1,5 @@
 # Copyright 2026 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
-from unittest.mock import patch
-
-# Ensures we're testing the current version.
-with patch.dict("sys.modules"):
-    import hissp
-
-    hissp.transpile(hissp.__package__, "macros")
-
 import hissp
 
 hissp.transpile(__package__, "test_macros")

--- a/tests/test_reader.py
+++ b/tests/test_reader.py
@@ -10,10 +10,10 @@ from unittest import TestCase
 from unittest.mock import ANY
 
 import hypothesis.strategies as st
-from hissp.reader import SoftSyntaxError
 from hypothesis import given
 
 from hissp import reader
+from hissp.reader import SoftSyntaxError
 
 UNICODE_ANY_ = [("unicode", ANY, ANY)]
 


### PR DESCRIPTION
Closes #281.

I'm going with the status quo `$#` gensyms and added `:#` sentinels. I feel like either way would be fine, but I don't have a compelling enough reason to go to the effort of swapping them.