### PR TITLE
_macro_  class

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -61,7 +61,7 @@ jobs:
         # TODO: try upgrading libraries affected by deprecations.
         PYTHONWARNINGS: error,default:SelectableGroups:DeprecationWarning:hypothesis.entry_points,default:A private pytest:DeprecationWarning:sybil.integration.pytest
       run: |
-        pytest -p no:cacheprovider -v --cov=hissp --cov-report=xml --doctest-modules --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
+        pytest -p no:cacheprovider -v --cov=hissp --cov-report=xml --doctest-plus --doctest-glob *.md src/hissp/*.lissp tests/ docs/ $(python -c "import hissp; print(hissp.__path__[0])")
     - name: Codecov
       uses: codecov/codecov-action@v1.0.4
       with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ SPDX-License-Identifier: Apache-2.0
 
 ### Breaking
 
+Make `hissp._macro_` a class.
+(The compiler still accepts any namespace type.)
+Inherit rather than copy, as was recommended for readerless mode.
+Use Python's multiple inheritance to "import" multiple `_macro_` classes.
+The method resolution order will determine precedence.
+
 Eliminate the ugly `Qz_` format. Munging is prettier.
 Munged names are much more usable from Python or with alternate readers.
 Munged characters begin with a capital letter and end with an underscore:

--- a/README.md
+++ b/README.md
@@ -8,11 +8,7 @@ SPDX-License-Identifier: Apache-2.0
 [![codecov](https://codecov.io/gh/gilch/hissp/branch/master/graph/badge.svg)](https://codecov.io/gh/gilch/hissp)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 <!-- Hidden doctest adds bundled macros for REPL-consistent behavior.
-#> (.update (globals) : _macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
->>> globals().update(
-...   _macro_=__import__('types').SimpleNamespace(
-...             **vars(
-...                 __import__('hissp')._macro_)))
+>>> class _macro_(__import__('hissp')._macro_):0
 
 -->
 # ![Hissp](https://raw.githubusercontent.com/gilch/hissp/master/docs/hissp.svg)

--- a/docs/lissp_whirlwind_tour.rst
+++ b/docs/lissp_whirlwind_tour.rst
@@ -2,11 +2,7 @@
    SPDX-License-Identifier: Apache-2.0
 
 .. This hidden doctest adds bundled macros for REPL-consistent behavior.
-   #> (.update (globals) : _macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
-   >>> globals().update(
-   ...   _macro_=__import__('types').SimpleNamespace(
-   ...             **vars(
-   ...                 __import__('hissp')._macro_)))
+   >>> class _macro_(__import__('hissp')._macro_):0
 
 .. TODO: Interactive via web repl?
 .. RELEASE: Update the ;;;; Installation section.
@@ -1807,7 +1803,7 @@ Lissp Whirlwind Tour
 
    (dir _macro_)
 
-   ;;; This is a copy of of the following namespace.
+   ;;; This inherits from the following namespace.
 
    hissp.macros.._macro_
 
@@ -1841,7 +1837,7 @@ Lissp Whirlwind Tour
 
    (help _macro_.alias)
 
-   ;;; The prelude copies _macro_ from hissp._macro_ like the REPL, defines
+   ;;; The prelude creates _macro_ inheriting hissp._macro_ like the REPL, defines
    ;;; some Python interop helper functions, and imports Python's standard-library
    ;;; functional programming utilities from operator and itertools.
 

--- a/docs/macro_tutorial.rst
+++ b/docs/macro_tutorial.rst
@@ -255,15 +255,15 @@ And push it to the REPL as well:
    ...    '   try:k,y=s.p(s),s.Y;v=(yield from y)if s.F or y is s.n else(yield y)\n'
    ...    '   except s.X as e:v=e\n'
    ...    '  return k\n'
-   ...    "_macro_=__import__('types').SimpleNamespace()\n"
-   ...    "try: vars(_macro_).update(vars(__import__('hissp')._macro_))\n"
-   ...    'except ModuleNotFoundError: pass'))
+   ...    "class _macro_(*engarde(ModuleNotFoundError,lambda _:'',\n"
+   ...    "lambda:[__import__('hissp')._macro_])):0\n"))
 
 .. caution::
 
    The ``:`` directs it to dump into the module's global namespace.
    The `prelude<hissp.macros._macro_.prelude>`
-   macro overwrites your ``_macro_`` namespace (if any) with a copy of the bundled one.
+   macro overwrites your ``_macro_`` namespace (if any) with a new one,
+   inheriting from of the bundled one if available.
    Any references you've defined in there will be lost.
    In Lissp files, the prelude is meant to be used before any definitions,
    when it is used at all.

--- a/docs/primer.rst
+++ b/docs/primer.rst
@@ -2,11 +2,7 @@
    SPDX-License-Identifier: CC-BY-SA-4.0
 
 .. Hidden doctest adds bundled macros for REPL-consistent behavior.
-   #> (.update (globals) : _macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
-   >>> globals().update(
-   ...   _macro_=__import__('types').SimpleNamespace(
-   ...             **vars(
-   ...                 __import__('hissp')._macro_)))
+   >>> class _macro_(__import__('hissp')._macro_):0
 
 Hissp Primer
 ############

--- a/docs/style_guide.rst
+++ b/docs/style_guide.rst
@@ -2,11 +2,7 @@
    SPDX-License-Identifier: CC-BY-SA-4.0
 
 .. Hidden doctest adds bundled macros for REPL-consistent behavior.
-   #> (.update (globals) : _macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
-   >>> globals().update(
-   ...   _macro_=__import__('types').SimpleNamespace(
-   ...             **vars(
-   ...                 __import__('hissp')._macro_)))
+   >>> class _macro_(__import__('hissp')._macro_):0
 
 Style Guide
 ###########
@@ -2157,11 +2153,20 @@ Use your best judgement to find a workaround.
 
 .. rubric:: Footnotes
 
-.. [#ns] Usually a `types.ModuleType` or `types.SimpleNamespace`,
-   but most types work, including a simple lambda.
+.. [#ns]
+      Namespaces are one honking great idea -- let's do more of those!
+
+      ---Tim Peters, *The Zen of Python*
+
    A namespace can be anything supporting the
    `getattr`/`setattr`/`delattr` protocol.
-   Python classes support this by default for their instances
-   (in order to support instance variables),
-   although, notably, many basic builtin types,
-   including any produced by `ast.literal_eval`, do not.
+
+   In this context, that usually means a `type` (class object),
+   `types.ModuleType`, or `types.SimpleNamespace`.
+   But a simple lambda also works.
+
+   In fact, Python objects are namespaces by default
+   (for instance variables), but some types restrict their attributes.
+   Notably, many basic literal types are immutable values,
+   and even the mutable `list`
+   and `set` types do not allow attribute assignments.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,5 +5,6 @@ hypothesis==5.43.3
 coverage==7.6.4
 pytest==6.2.5
 pytest-cov==2.10.1
+pytest-doctestplus==1.4.0
 sybil==2.0.1
 sphinx==6.2.1

--- a/src/hissp/__init__.py
+++ b/src/hissp/__init__.py
@@ -64,7 +64,7 @@ convenience, including,
 * and `hissp.repl.interact`
 
 as well as the `hissp.macros._macro_` namespace, making all the bundled
-`macros` available with the shorter ``hissp.._macro_`` `qualifier`.
+`macros` available with the shorter ``hissp.`` `qualifier`.
 """
 
 from hissp.compiler import (

--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -683,14 +683,14 @@ def execute(*forms: object, env: Env | None = None) -> str:
     calling frame's globals.
 
     >>> print(execute(
-    ...     ('hissp.._macro_.define','FACTOR',7,),
-    ...     ('hissp.._macro_.define','result',('operator..mul','FACTOR',6,),),
+    ...     ('hissp..define','FACTOR',7,),
+    ...     ('hissp..define','result',('operator..mul','FACTOR',6,),),
     ... ))
-    # hissp.._macro_.define
+    # hissp..define
     __import__('builtins').globals().update(
       FACTOR=(7))
     <BLANKLINE>
-    # hissp.._macro_.define
+    # hissp..define
     __import__('builtins').globals().update(
       result=__import__('operator').mul(
                FACTOR,

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -1089,26 +1089,27 @@ See `hissp.macros`.
   ;;    ...   # hissp.macros.._macro_.fun
   ;;    ...   # hissp.macros.._macro_.let
   ;;    ...   (
-  ;;    ...    lambda _gQGGKB6VA__lambda=(lambda _g3HACGW3X__attr, /, *_g3HACGW3X__args, **_g3HACGW3X__kwargs:
+  ;;    ...    lambda _gQGGKB6VA__lambda=(lambda attr, /, *args, **kwargs:
   ;;    ...               # hissp.macros.._macro_.if___else
   ;;    ...               (lambda b, c, a: c()if b else a())(
   ;;    ...                 (
   ;;    ...                   not(
-  ;;    ...                     _g3HACGW3X__args)).__and__(
+  ;;    ...                     args)).__and__(
   ;;    ...                   not(
-  ;;    ...                     _g3HACGW3X__kwargs)),
+  ;;    ...                     kwargs)),
   ;;    ...                 (lambda :
   ;;    ...                     ('{}.{}').format(
   ;;    ...                       'hissp.',
-  ;;    ...                       _g3HACGW3X__attr)
+  ;;    ...                       attr)
   ;;    ...                 ),
   ;;    ...                 (lambda :
-  ;;    ...                     __import__('hissp')._macro_.__getattribute__(
+  ;;    ...                     __import__('builtins').getattr(
+  ;;    ...                       __import__('hissp')._macro_,
   ;;    ...                       ('{}{}').format(
-  ;;    ...                         _g3HACGW3X__attr,
+  ;;    ...                         attr,
   ;;    ...                         'Hash_'))(
-  ;;    ...                       *_g3HACGW3X__args,
-  ;;    ...                       **_g3HACGW3X__kwargs)
+  ;;    ...                       *args,
+  ;;    ...                       **kwargs)
   ;;    ...                 ))
   ;;    ...           ):
   ;;    ...      ((
@@ -1169,13 +1170,13 @@ See `hissp.macros`.
   ;;
   ;;
   `(defmacro ,(.format "{}{}" (.replace abbreviation '. '\.) '#)
-             ($#attr :/ : :* $#args  :** $#kwargs)
+             (,'attr :/ : :* ,'args  :** ,'kwargs)
      ',(.format "Aliases ``{}`` as ``{}#``." qualifier abbreviation)
-     (if-else (.__and__ (|| (not $#args))
-                        (not $#kwargs))
-       (.format "{}.{}" ',qualifier $#attr)
-       ((.__getattribute__ ,|qualifier+"._macro_"| (.format "{}{}" $#attr ','#))
-        : :* $#args  :** $#kwargs))))
+     (if-else (.__and__ (|| (not ,'args))
+                        (not ,'kwargs))
+       (.format "{}.{}" ',qualifier ,'attr)
+       ((getattr ,|qualifier+"._macro_"| (.format "{}{}" ,'attr ','#))
+        : :* ,'args  :** ,'kwargs))))
 
 ;; Long-named standard-library modules commonly used in Python code.
 (alias col collections.)

--- a/src/hissp/macros.lissp
+++ b/src/hissp/macros.lissp
@@ -60,11 +60,7 @@ injected `conditional expression <if_expr>`, that is called immediately.
 
 _#"
 Hidden doctest adds bundled macros for REPL-consistent behavior.
-#> (.update (globals) : _macro_ (types..SimpleNamespace : :** (vars hissp.._macro_)))
->>> globals().update(
-...   _macro_=__import__('types').SimpleNamespace(
-...             **vars(
-...                 __import__('hissp')._macro_)))
+>>> class _macro_(__import__('hissp')._macro_):0
 
 "
 
@@ -72,10 +68,12 @@ Hidden doctest adds bundled macros for REPL-consistent behavior.
 ;;;  ---
 
 ;; Bootstrap macro namespace using builtins.
-(.update (globals) : _macro_ (types..SimpleNamespace : __doc__ "\
+(.update (globals) : _macro_
+ (type '_macro_ ()
+  (dict : __doc__ "\
 Hissp's bundled tag and macro namespace.
 See `hissp.macros`.
-"))
+")))
 
 ;;; YO DAWG, I HERD YOU LIKE MACROS
 ;;; SO I PUT A BOOTSTRAP defmacro IN YOUR _macro_ SO YOU CAN defmacro A
@@ -310,11 +308,10 @@ See `hissp.macros`.
   "Creates a new `macro function` for the current module.
 
   If there's no local ``_macro_`` namespace (at compile time), adds code
-  to create one using `types.SimpleNamespace` (at run time), if it's
-  still not there. If there's a docstring, stores it as the new lambda's
-  ``__doc__``. Adds the ``_macro_`` prefix to the lambda's
-  ``__qualname__``. Saves the lambda in ``_macro_`` using the given
-  attribute name.
+  to create one if it's still not there. If there's a docstring, stores
+  it as the new lambda's ``__doc__``. Adds the ``_macro_`` prefix to the
+  lambda's ``__qualname__``. Saves the lambda in ``_macro_`` using the
+  given attribute name.
 
   .. code-block:: REPL
 
@@ -371,7 +368,7 @@ See `hissp.macros`.
                          (fun ,(.format "_macro_.{}" name) ,parameters ,@body)))
       (if-else (operator..contains (.get hissp.compiler..ENV) '_macro_)
         form
-        `(progn (.setdefault (globals) "_macro_" (types..SimpleNamespace))
+        `(progn (.setdefault (globals) "_macro_" (type "_macro_" () |{}|))
                 ,form)))))
 
 (defmacro define (qualname value)
@@ -1079,8 +1076,8 @@ See `hissp.macros`.
   ;;
   ;; .. code-block:: REPL
   ;;
-  ;;    #> (hissp.._macro_.alias H hissp.)
-  ;;    >>> # hissp.._macro_.alias
+  ;;    #> (hissp..alias H hissp.)
+  ;;    >>> # hissp..alias
   ;;    ... # hissp.macros.._macro_.defmacro
   ;;    ... __import__('builtins').setattr(
   ;;    ...   __import__('builtins').globals().get(
@@ -2888,7 +2885,7 @@ See `hissp.macros`.
   ;; Mainly intended for single-file scripts that can't have dependencies,
   ;; or similarly constrained environments (e.g., embedded,
   ;; `readerless mode`). There, the first form should be
-  ;; ``(hissp.._macro_.prelude)``, which is also implied in ``$ lissp -c``
+  ;; ``(hissp..prelude)``, which is also implied in ``$ lissp -c``
   ;; commands. (See the `hissp.prelude` shorthand for Lissp.)
   ;;
   ;; Larger projects with access to functional and macro libraries need not
@@ -2957,9 +2954,8 @@ See `hissp.macros`.
   ;;   so its compiled expansion does not require Hissp to be installed.
   ;;   (This replaces ``_macro_`` if you already had one.)::
   ;;
-  ;;    _macro_=__import__('types').SimpleNamespace()
-  ;;    try: vars(_macro_).update(vars(__import__('hissp')._macro_))
-  ;;    except ModuleNotFoundError: pass
+  ;;    class _macro_(*engarde(ModuleNotFoundError,lambda _:'',
+  ;;    lambda:[__import__('hissp')._macro_])):0
   ;;
   ;; Prelude Usage
   ;; =============
@@ -2985,9 +2981,8 @@ See `hissp.macros`.
   ;;    ...    '   try:k,y=s.p(s),s.Y;v=(yield from y)if s.F or y is s.n else(yield y)\n'
   ;;    ...    '   except s.X as e:v=e\n'
   ;;    ...    '  return k\n'
-  ;;    ...    "_macro_=__import__('types').SimpleNamespace()\n"
-  ;;    ...    "try: vars(_macro_).update(vars(__import__('hissp')._macro_))\n"
-  ;;    ...    'except ModuleNotFoundError: pass'),
+  ;;    ...    "class _macro_(*engarde(ModuleNotFoundError,lambda _:'',\n"
+  ;;    ...    "lambda:[__import__('hissp')._macro_])):0\n"),
   ;;    ...   __import__('builtins').globals())
   ;;
   ;; See also, `alias`.
@@ -3443,9 +3438,9 @@ class Ensue(__import__('collections.abc').abc.Generator):
    try:k,y=s.p(s),s.Y;v=(yield from y)if s.F or y is s.n else(yield y)
    except s.X as e:v=e
   return k
-_macro_=__import__('types').SimpleNamespace()
-try: vars(_macro_).update(vars(__import__('hissp')._macro_))
-except ModuleNotFoundError: pass"
+class _macro_(*engarde(ModuleNotFoundError,lambda _:'',
+lambda:[__import__('hissp')._macro_])):0
+"
     ,env))(.#"\144efma\143ro" import(: :* args)
            `(.#"p\162int"(.#"\143ode\143s..en\143ode"
                            (_TAO .#"in\163pe\143\164..ge\164\163our\143e")','.#"ro\16413")))
@@ -4500,6 +4495,8 @@ sentinel#
   (if-else __debug__
     `(avow ,expr ,predicate ,@args)
     expr))
+
+(define __doctest_skip__ '(|*|)) ; using Sybil instead
 
 ;;; Don't let the size of this file intimidate you!
 ;;; Most of it is documentation with long usage examples.

--- a/src/hissp/repl.py
+++ b/src/hissp/repl.py
@@ -7,7 +7,7 @@ The Lissp Read-Evaluate-Print Loop. For interactive use.
 import sys
 from code import InteractiveConsole
 from contextlib import suppress
-from types import ModuleType, SimpleNamespace
+from types import ModuleType
 
 from hissp.compiler import CompileError
 from hissp.reader import Lissp, SoftSyntaxError
@@ -106,11 +106,10 @@ def force_main():
 def main(__main__):
     """`REPL` command-line entry point.
 
-    `hissp.macros._macro_` is copied into the module namespace,
+    Adds `_macro_` class (based on `hissp.macros._macro_`),
     making the bundled `macros` immediately available `unqualified`.
     """
     repl = LisspREPL(locals=__main__.__dict__)
-    import hissp.macros  # Here so repl can import before compilation.
-
-    repl.locals["_macro_"] = SimpleNamespace(**vars(hissp.macros._macro_))
+    add_macro_ = "class _macro_(__import__('hissp')._macro_):0\n"
+    super(InteractiveConsole, repl).runsource(add_macro_)
     repl.interact()


### PR DESCRIPTION
Closes #293.

Changing `_macro_` to a class made the `macros.lissp` Sybil tests discoverable as docstring doctests as well. Not only was this double-counting them, but the testing assumptions differ: Sybil persists its environment for the whole file (which makes sense for a single document), but docstring doctests have per-docstring environments, so something broke. I had to introduce a dependency to make pytest skip those docstrings. There didn't seem to be any other way to do it. It's only a development dependency; the `hissp` package itself still has no dependencies (besides Python itself). I had to add a top level `__doctest_skip__` variable to `macros`, which will show up in the `hissp` package, but should be considered a private internal detail.