### PR TITLE
Fall back to a higher pickle protocol when protocol 0 fails

### DIFF
--- a/src/hissp/compiler.py
+++ b/src/hissp/compiler.py
@@ -591,7 +591,15 @@ class Compiler:
     def pickle(self, form: object) -> str:
         """Compile to `pickle.loads`. The final fallback for `atomic`."""
         protocols = 0, MAX_PROTOCOL
-        pickles = [repr(pickletools.optimize(pickle.dumps(form, p))) for p in protocols]
+        pickles = []
+        for p in protocols:
+            # A protocol that can't represent the form isn't a candidate,
+            # but a higher one still might be. E.g. protocol 0 can't pickle
+            # an object of a class defining __slots__ without __getstate__.
+            with suppress(Exception):
+                pickles.append(repr(pickletools.optimize(pickle.dumps(form, p))))
+        if not pickles:
+            pickle.dumps(form, MAX_PROTOCOL)  # Raise the relevant error.
         code = min(pickles, key=len)
         r = repr(form).replace("\n", "\n  # ")
         return f"# {r}\n__import__({pickle.__name__!r}).loads({code})"

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -34,6 +34,13 @@ class Slotted:
     __slots__ = "item"
 
 
+class Unpicklable:
+    """No protocol can pickle this."""
+
+    def __reduce__(self):
+        return 42
+
+
 class TestCompileGeneral(TestCase):
     @given(
         literals
@@ -54,10 +61,10 @@ class TestCompileGeneral(TestCase):
         self.assertIsInstance(eval(compiler.Compiler().pickle(Slotted())), Slotted)
 
     def test_compile_pickle_no_protocol_works(self):
-        # No protocol can pickle a lambda, so the error from the highest
+        # No protocol can pickle this, so the error from the highest
         # protocol is re-raised and reported as usual.
         c = compiler.Compiler()
-        self.assertIn("PicklingError", c.pickle(lambda: None))
+        self.assertIn("PicklingError", c.pickle(Unpicklable()))
         self.assertIsInstance(c.error, pickle.PicklingError)
 
     def test_module_not_found(self):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -27,6 +27,12 @@ literals = st.recursive(
 )
 
 
+class Slotted:
+    """Protocol 0 can't pickle this, but a higher protocol can."""
+
+    __slots__ = "item"
+
+
 class TestCompileGeneral(TestCase):
     @given(
         literals
@@ -40,6 +46,11 @@ class TestCompileGeneral(TestCase):
     )
     def test_compile_pickle(self, form):
         self.assertEqual(form, eval(compiler.Compiler().pickle(form)))
+
+    def test_compile_pickle_protocol_fallback(self):
+        # Protocol 0 raises for a __slots__ class without __getstate__,
+        # but a higher protocol handles it, so compilation must not fail.
+        self.assertIsInstance(eval(compiler.Compiler().pickle(Slotted())), Slotted)
 
     def test_module_not_found(self):
         self.assertEqual(

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -1,5 +1,6 @@
 # Copyright 2019, 2020, 2021, 2022 Matthew Egan Odendahl
 # SPDX-License-Identifier: Apache-2.0
+import pickle
 import textwrap
 from unittest import TestCase
 
@@ -51,6 +52,13 @@ class TestCompileGeneral(TestCase):
         # Protocol 0 raises for a __slots__ class without __getstate__,
         # but a higher protocol handles it, so compilation must not fail.
         self.assertIsInstance(eval(compiler.Compiler().pickle(Slotted())), Slotted)
+
+    def test_compile_pickle_no_protocol_works(self):
+        # No protocol can pickle a lambda, so the error from the highest
+        # protocol is re-raised and reported as usual.
+        c = compiler.Compiler()
+        self.assertIn("PicklingError", c.pickle(lambda: None))
+        self.assertIsInstance(c.error, pickle.PicklingError)
 
     def test_module_not_found(self):
         self.assertEqual(


### PR DESCRIPTION
Closes #291

`Compiler.pickle()` built its candidate list eagerly for protocol 0 and `MAX_PROTOCOL`, so a form protocol 0 cannot represent — an object of a class defining `__slots__` without `__getstate__` — raised before the higher protocol was tried. Each protocol is now attempted independently and only the successful ones are candidates; if none succeed the pickling error is re-raised, so genuinely unpicklable forms still fail as before.

Regression test added in `tests/test_compiler.py`; it fails on master (`SyntaxError` from the CompileError comment) and passes with the fix. Black clean; the rest of the suite is unchanged from baseline.

This change was prepared with AI assistance; the regression test was run locally and fails without the fix.
